### PR TITLE
Apply Toolbox design: salmon palette, DM fonts, NavBar, Footer, ToolCard

### DIFF
--- a/src/app/calculator/Calculator.tsx
+++ b/src/app/calculator/Calculator.tsx
@@ -1,241 +1,482 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState, useCallback, useEffect } from "react";
+import { useRouter } from "next/navigation";
 
-type Operator = "+" | "-" | "*" | "/";
-
-type State = {
-  current: string;
-  previous: number | null;
-  operator: Operator | null;
-  justEvaluated: boolean;
-  error: boolean;
-};
-
-const initialState: State = {
-  current: "0",
-  previous: null,
-  operator: null,
-  justEvaluated: false,
-  error: false,
-};
-
-const OPERATOR_SYMBOLS: Record<Operator, string> = {
-  "+": "+",
-  "-": "−",
-  "*": "×",
-  "/": "÷",
-};
-
-function compute(a: number, b: number, op: Operator): number | null {
-  switch (op) {
-    case "+":
-      return a + b;
-    case "-":
-      return a - b;
-    case "*":
-      return a * b;
-    case "/":
-      return b === 0 ? null : a / b;
-  }
-}
-
-function formatNumber(n: number): string {
-  if (!Number.isFinite(n)) return "Error";
-  const rounded = Math.round(n * 1e12) / 1e12;
-  return String(rounded);
-}
-
-function inputDigit(state: State, digit: string): State {
-  if (state.error) return { ...initialState, current: digit };
-  if (state.justEvaluated) {
-    return { ...initialState, current: digit };
-  }
-  if (state.current === "0") {
-    return { ...state, current: digit };
-  }
-  if (state.current.replace("-", "").replace(".", "").length >= 15) {
-    return state;
-  }
-  return { ...state, current: state.current + digit };
-}
-
-function inputDecimal(state: State): State {
-  if (state.error) return { ...initialState, current: "0." };
-  if (state.justEvaluated) {
-    return { ...initialState, current: "0." };
-  }
-  if (state.current.includes(".")) return state;
-  return { ...state, current: state.current + "." };
-}
-
-function chooseOperator(state: State, op: Operator): State {
-  if (state.error) return state;
-  const currentNum = parseFloat(state.current);
-
-  if (state.previous !== null && state.operator && !state.justEvaluated) {
-    const result = compute(state.previous, currentNum, state.operator);
-    if (result === null) {
-      return { ...initialState, current: "Error", error: true };
-    }
-    return {
-      current: formatNumber(result),
-      previous: result,
-      operator: op,
-      justEvaluated: true,
-      error: false,
-    };
-  }
-
-  return {
-    current: state.current,
-    previous: currentNum,
-    operator: op,
-    justEvaluated: true,
-    error: false,
-  };
-}
-
-function evaluate(state: State): State {
-  if (state.error) return state;
-  if (state.operator === null || state.previous === null) return state;
-  const currentNum = parseFloat(state.current);
-  const result = compute(state.previous, currentNum, state.operator);
-  if (result === null) {
-    return { ...initialState, current: "Error", error: true };
-  }
-  return {
-    current: formatNumber(result),
-    previous: null,
-    operator: null,
-    justEvaluated: true,
-    error: false,
-  };
-}
-
-function backspace(state: State): State {
-  if (state.error || state.justEvaluated) return state;
-  if (state.current.length <= 1 || (state.current.length === 2 && state.current.startsWith("-"))) {
-    return { ...state, current: "0" };
-  }
-  return { ...state, current: state.current.slice(0, -1) };
-}
+type HistoryEntry = { expr: string; result: string };
+type KeyType = "num" | "op" | "eq" | "clr";
 
 export default function Calculator() {
-  const [state, setState] = useState<State>(initialState);
+  const router = useRouter();
+  const [display, setDisplay] = useState("0");
+  const [expression, setExpression] = useState("");
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [justEvaluated, setJustEvaluated] = useState(false);
 
-  const onDigit = useCallback(
-    (d: string) => setState((s) => inputDigit(s, d)),
-    [],
+  const handleDigit = useCallback(
+    (d: string) => {
+      if (justEvaluated) {
+        setDisplay(d);
+        setExpression("");
+        setJustEvaluated(false);
+        return;
+      }
+      setDisplay((prev) =>
+        prev === "0" ? d : prev.length < 14 ? prev + d : prev
+      );
+    },
+    [justEvaluated]
   );
-  const onDecimal = useCallback(() => setState((s) => inputDecimal(s)), []);
-  const onOperator = useCallback(
-    (op: Operator) => setState((s) => chooseOperator(s, op)),
-    [],
+
+  const handleDecimal = useCallback(() => {
+    if (justEvaluated) {
+      setDisplay("0,");
+      setExpression("");
+      setJustEvaluated(false);
+      return;
+    }
+    if (!display.includes(",")) setDisplay((prev) => prev + ",");
+  }, [justEvaluated, display]);
+
+  const handleOperator = useCallback(
+    (op: string) => {
+      setJustEvaluated(false);
+      const displayOp: Record<string, string> = {
+        "+": "+",
+        "-": "−",
+        "*": "×",
+        "/": "÷",
+      };
+      setExpression(display + " " + (displayOp[op] ?? op) + " ");
+      setDisplay("0");
+    },
+    [display]
   );
-  const onEquals = useCallback(() => setState((s) => evaluate(s)), []);
-  const onClear = useCallback(() => setState(initialState), []);
-  const onBackspace = useCallback(() => setState((s) => backspace(s)), []);
+
+  const handleEquals = useCallback(() => {
+    try {
+      const expr = expression + display;
+      const evalExpr = expr
+        .replace(/,/g, ".")
+        .replace(/÷/g, "/")
+        .replace(/×/g, "*")
+        .replace(/−/g, "-");
+      // eslint-disable-next-line no-new-func
+      const result = Function(
+        '"use strict"; return (' + evalExpr + ")"
+      )() as number;
+      const resultStr = new Intl.NumberFormat("fr-FR", {
+        maximumFractionDigits: 10,
+      }).format(result);
+      setHistory((h) => [{ expr, result: resultStr }, ...h].slice(0, 6));
+      setDisplay(resultStr);
+      setExpression(expr + " =");
+      setJustEvaluated(true);
+    } catch {
+      setDisplay("Erreur");
+      setExpression("");
+    }
+  }, [expression, display]);
+
+  const handleClear = useCallback(() => {
+    setDisplay("0");
+    setExpression("");
+    setJustEvaluated(false);
+  }, []);
+
+  const handleSign = useCallback(() => {
+    setDisplay((d) => (d.startsWith("-") ? d.slice(1) : "-" + d));
+  }, []);
+
+  const handlePercent = useCallback(() => {
+    try {
+      const val = parseFloat(display.replace(",", ".")) / 100;
+      setDisplay(
+        new Intl.NumberFormat("fr-FR", { maximumFractionDigits: 10 }).format(
+          val
+        )
+      );
+    } catch {
+      /* ignore */
+    }
+  }, [display]);
+
+  const handleBackspace = useCallback(() => {
+    if (justEvaluated) return;
+    setDisplay((d) => (d.length > 1 ? d.slice(0, -1) : "0"));
+  }, [justEvaluated]);
 
   useEffect(() => {
-    function handleKey(e: KeyboardEvent) {
-      const k = e.key;
-      if (/^[0-9]$/.test(k)) {
-        onDigit(k);
-      } else if (k === ".") {
-        onDecimal();
-      } else if (k === "+" || k === "-" || k === "*" || k === "/") {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key >= "0" && e.key <= "9") handleDigit(e.key);
+      else if (e.key === ".") handleDecimal();
+      else if (e.key === "+") handleOperator("+");
+      else if (e.key === "-") handleOperator("-");
+      else if (e.key === "*") handleOperator("*");
+      else if (e.key === "/") {
         e.preventDefault();
-        onOperator(k);
-      } else if (k === "Enter" || k === "=") {
-        e.preventDefault();
-        onEquals();
-      } else if (k === "Backspace") {
-        onBackspace();
-      } else if (k === "Escape") {
-        onClear();
-      }
-    }
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [onDigit, onDecimal, onOperator, onEquals, onBackspace, onClear]);
+        handleOperator("/");
+      } else if (e.key === "Enter" || e.key === "=") handleEquals();
+      else if (e.key === "Backspace") handleBackspace();
+      else if (e.key === "Escape") handleClear();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [
+    handleDigit,
+    handleDecimal,
+    handleOperator,
+    handleEquals,
+    handleBackspace,
+    handleClear,
+  ]);
 
-  const displayValue = state.error ? "Error" : state.current;
-
-  const digitClass =
-    "rounded-xl p-4 text-xl font-medium bg-zinc-200 hover:bg-zinc-300 dark:bg-zinc-800 dark:hover:bg-zinc-700 active:scale-95 transition";
-  const opClass =
-    "rounded-xl p-4 text-xl font-semibold bg-orange-500 hover:bg-orange-400 text-white active:scale-95 transition";
-  const utilClass =
-    "rounded-xl p-4 text-xl font-medium bg-zinc-300 hover:bg-zinc-400 dark:bg-zinc-700 dark:hover:bg-zinc-600 active:scale-95 transition";
-  const equalsClass =
-    "rounded-xl p-4 text-xl font-semibold bg-orange-600 hover:bg-orange-500 text-white active:scale-95 transition";
+  const fontSize =
+    display.length > 11 ? "24px" : display.length > 7 ? "32px" : "42px";
 
   return (
-    <div className="w-full max-w-sm rounded-2xl bg-white dark:bg-zinc-900 shadow-xl p-4 border border-zinc-200 dark:border-zinc-800">
-      <div
-        aria-live="polite"
-        className="mb-4 rounded-xl bg-zinc-100 dark:bg-zinc-950 px-4 py-6 text-right text-4xl font-mono tracking-tight overflow-x-auto"
-      >
-        {displayValue}
-        {state.operator && !state.error && (
-          <span className="ml-2 text-orange-500">
-            {OPERATOR_SYMBOLS[state.operator]}
-          </span>
+    <div
+      style={{
+        fontFamily: "var(--font-dm-sans)",
+        maxWidth: "960px",
+        margin: "0 auto",
+        padding: "32px 24px",
+        display: "grid",
+        gridTemplateColumns: "1fr 280px",
+        gap: "32px",
+        alignItems: "start",
+      }}
+    >
+      {/* Main calculator */}
+      <div>
+        <button
+          onClick={() => router.push("/")}
+          style={{
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            gap: "6px",
+            color: "#7A5550",
+            fontSize: "13px",
+            fontWeight: 500,
+            padding: "0 0 20px 0",
+            marginLeft: "-4px",
+            fontFamily: "var(--font-dm-sans)",
+          }}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          >
+            <path d="M9 2L4 7l5 5" />
+          </svg>
+          Tous les outils
+        </button>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "12px",
+            marginBottom: "24px",
+          }}
+        >
+          <div
+            style={{
+              width: "40px",
+              height: "40px",
+              borderRadius: "10px",
+              background: "#FEF0ED",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "#E07B72",
+              flexShrink: 0,
+            }}
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            >
+              <rect x="4" y="2" width="16" height="20" rx="2" />
+              <line x1="8" y1="6" x2="16" y2="6" />
+              <line x1="8" y1="10" x2="10" y2="10" />
+              <line x1="12" y1="10" x2="14" y2="10" />
+              <line x1="16" y1="10" x2="16" y2="10" />
+              <line x1="8" y1="14" x2="10" y2="14" />
+              <line x1="12" y1="14" x2="14" y2="14" />
+              <line x1="16" y1="14" x2="16" y2="14" />
+              <line x1="8" y1="18" x2="10" y2="18" />
+              <line x1="12" y1="18" x2="14" y2="18" />
+              <line x1="16" y1="18" x2="16" y2="18" />
+            </svg>
+          </div>
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--font-dm-serif)",
+                fontSize: "22px",
+                color: "#2C1A17",
+              }}
+            >
+              Calculatrice
+            </div>
+            <div style={{ fontSize: "12px", color: "#B89490" }}>
+              Calculs simples et rapides
+            </div>
+          </div>
+        </div>
+
+        {/* Display */}
+        <div
+          aria-live="polite"
+          style={{
+            background: "#FEF0ED",
+            border: "1px solid #EDD9D5",
+            borderRadius: "14px",
+            padding: "20px 24px",
+            marginBottom: "16px",
+            textAlign: "right",
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "var(--font-jetbrains-mono)",
+              fontSize: "13px",
+              color: "#B89490",
+              minHeight: "18px",
+              marginBottom: "6px",
+            }}
+          >
+            {expression || " "}
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--font-jetbrains-mono)",
+              fontSize,
+              fontWeight: 500,
+              color: "#2C1A17",
+              letterSpacing: "-0.02em",
+              lineHeight: 1.1,
+              transition: "font-size 100ms",
+            }}
+          >
+            {display}
+          </div>
+        </div>
+
+        {/* Keypad */}
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(4, 1fr)",
+            gap: "8px",
+          }}
+        >
+          <CalcKey label="AC" type="clr" onClick={handleClear} />
+          <CalcKey label="±" type="op" onClick={handleSign} />
+          <CalcKey label="%" type="op" onClick={handlePercent} />
+          <CalcKey label="÷" type="op" onClick={() => handleOperator("/")} />
+
+          {[7, 8, 9].map((n) => (
+            <CalcKey
+              key={n}
+              label={String(n)}
+              onClick={() => handleDigit(String(n))}
+            />
+          ))}
+          <CalcKey label="×" type="op" onClick={() => handleOperator("*")} />
+
+          {[4, 5, 6].map((n) => (
+            <CalcKey
+              key={n}
+              label={String(n)}
+              onClick={() => handleDigit(String(n))}
+            />
+          ))}
+          <CalcKey label="−" type="op" onClick={() => handleOperator("-")} />
+
+          {[1, 2, 3].map((n) => (
+            <CalcKey
+              key={n}
+              label={String(n)}
+              onClick={() => handleDigit(String(n))}
+            />
+          ))}
+          <CalcKey label="+" type="op" onClick={() => handleOperator("+")} />
+
+          <CalcKey label="0" wide onClick={() => handleDigit("0")} />
+          <CalcKey label="," onClick={handleDecimal} />
+          <CalcKey label="=" type="eq" onClick={handleEquals} />
+        </div>
+      </div>
+
+      {/* History sidebar */}
+      <div style={{ paddingTop: "66px" }}>
+        <div
+          style={{
+            fontSize: "11px",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "#B89490",
+            marginBottom: "12px",
+            fontFamily: "var(--font-dm-sans)",
+          }}
+        >
+          Historique
+        </div>
+
+        {history.length === 0 ? (
+          <div
+            style={{
+              fontSize: "13px",
+              color: "#D4B8B4",
+              textAlign: "center",
+              padding: "32px 0",
+              fontFamily: "var(--font-dm-sans)",
+            }}
+          >
+            Vos calculs apparaîtront ici
+          </div>
+        ) : (
+          history.map((h, i) => (
+            <div
+              key={i}
+              onClick={() => {
+                setDisplay(h.result);
+                setExpression("");
+                setJustEvaluated(true);
+              }}
+              style={{
+                background: i === 0 ? "#FEF0ED" : "white",
+                border: "1px solid #EDD9D5",
+                borderRadius: "8px",
+                padding: "10px 14px",
+                marginBottom: "8px",
+                cursor: "pointer",
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: "var(--font-jetbrains-mono)",
+                  fontSize: "11px",
+                  color: "#B89490",
+                  marginBottom: "2px",
+                }}
+              >
+                {h.expr}
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-jetbrains-mono)",
+                  fontSize: "16px",
+                  fontWeight: 500,
+                  color: "#2C1A17",
+                }}
+              >
+                {h.result}
+              </div>
+            </div>
+          ))
+        )}
+
+        {history.length > 0 && (
+          <button
+            onClick={() => setHistory([])}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontSize: "11px",
+              color: "#B89490",
+              padding: "4px 0",
+              fontFamily: "var(--font-dm-sans)",
+            }}
+          >
+            Effacer l&apos;historique
+          </button>
         )}
       </div>
-
-      <div className="grid grid-cols-4 gap-2">
-        <button type="button" onClick={onClear} className={utilClass} aria-label="Clear">
-          C
-        </button>
-        <button type="button" onClick={onBackspace} className={utilClass} aria-label="Backspace">
-          ⌫
-        </button>
-        <div aria-hidden />
-        <button type="button" onClick={() => onOperator("/")} className={opClass} aria-label="Divide">
-          ÷
-        </button>
-
-        <button type="button" onClick={() => onDigit("7")} className={digitClass}>7</button>
-        <button type="button" onClick={() => onDigit("8")} className={digitClass}>8</button>
-        <button type="button" onClick={() => onDigit("9")} className={digitClass}>9</button>
-        <button type="button" onClick={() => onOperator("*")} className={opClass} aria-label="Multiply">
-          ×
-        </button>
-
-        <button type="button" onClick={() => onDigit("4")} className={digitClass}>4</button>
-        <button type="button" onClick={() => onDigit("5")} className={digitClass}>5</button>
-        <button type="button" onClick={() => onDigit("6")} className={digitClass}>6</button>
-        <button type="button" onClick={() => onOperator("-")} className={opClass} aria-label="Subtract">
-          −
-        </button>
-
-        <button type="button" onClick={() => onDigit("1")} className={digitClass}>1</button>
-        <button type="button" onClick={() => onDigit("2")} className={digitClass}>2</button>
-        <button type="button" onClick={() => onDigit("3")} className={digitClass}>3</button>
-        <button type="button" onClick={() => onOperator("+")} className={opClass} aria-label="Add">
-          +
-        </button>
-
-        <button
-          type="button"
-          onClick={() => onDigit("0")}
-          className={`${digitClass} col-span-2`}
-        >
-          0
-        </button>
-        <button type="button" onClick={onDecimal} className={digitClass}>
-          .
-        </button>
-        <button type="button" onClick={onEquals} className={equalsClass} aria-label="Equals">
-          =
-        </button>
-      </div>
-
-      <p className="mt-4 text-center text-xs text-zinc-500">
-        Clavier pris en charge : chiffres, + − × ÷, Entrée, Retour arrière, Échap
-      </p>
     </div>
+  );
+}
+
+function CalcKey({
+  label,
+  type = "num",
+  wide,
+  onClick,
+}: {
+  label: string;
+  type?: KeyType;
+  wide?: boolean;
+  onClick: () => void;
+}) {
+  const [pressed, setPressed] = useState(false);
+
+  const styles: Record<KeyType, React.CSSProperties> = {
+    num: {
+      background: "white",
+      border: "1px solid #EDD9D5",
+      color: "#2C1A17",
+      boxShadow: "0 2px 4px rgba(180,80,60,0.05)",
+    },
+    op: {
+      background: "#FEF0ED",
+      border: "1px solid #F5C4BC",
+      color: "#C9524A",
+      boxShadow: "none",
+    },
+    eq: {
+      background: "#E07B72",
+      border: "none",
+      color: "white",
+      boxShadow: "0 3px 10px rgba(180,80,60,0.28)",
+    },
+    clr: {
+      background: "#F9E5E3",
+      border: "1px solid #F0B4AC",
+      color: "#C0392B",
+      boxShadow: "none",
+    },
+  };
+
+  return (
+    <button
+      aria-label={label}
+      onMouseDown={() => setPressed(true)}
+      onMouseUp={() => {
+        setPressed(false);
+        onClick();
+      }}
+      onMouseLeave={() => setPressed(false)}
+      style={{
+        gridColumn: wide ? "span 2" : "span 1",
+        height: "58px",
+        ...styles[type],
+        borderRadius: "10px",
+        cursor: "pointer",
+        fontFamily: "var(--font-dm-sans)",
+        fontSize: "16px",
+        fontWeight: 500,
+        transform: pressed ? "scale(0.93)" : "scale(1)",
+        transition: "transform 80ms, box-shadow 150ms",
+      }}
+    >
+      {label}
+    </button>
   );
 }

--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -1,24 +1,14 @@
-import Link from "next/link";
 import type { Metadata } from "next";
 import Calculator from "./Calculator";
 
 export const metadata: Metadata = {
   title: "Calculatrice",
-  description: "Calculatrice simple avec les 4 opérateurs.",
+  description: "Calculs simples et rapides avec historique intégré.",
 };
 
 export default function CalculatorPage() {
   return (
-    <main className="flex-1 flex flex-col items-center px-4 py-10 gap-6">
-      <div className="w-full max-w-sm">
-        <Link
-          href="/"
-          className="text-sm text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 transition"
-        >
-          ← Retour aux outils
-        </Link>
-      </div>
-      <h1 className="text-2xl font-semibold">Calculatrice</h1>
+    <main style={{ flex: 1 }}>
       <Calculator />
     </main>
   );

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+export default function Footer() {
+  return (
+    <footer
+      style={{
+        borderTop: "1px solid #EDD9D5",
+        padding: "24px 32px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        background: "#FDF6F4",
+        flexWrap: "wrap",
+        gap: "12px",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--font-dm-sans)",
+          fontSize: "12px",
+          color: "#B89490",
+        }}
+      >
+        © 2026 Toolbox — Outils simples, résultats clairs.
+      </span>
+      <div style={{ display: "flex", gap: "16px" }}>
+        {["Confidentialité", "Conditions"].map((label) => (
+          <button
+            key={label}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontFamily: "var(--font-dm-sans)",
+              fontSize: "12px",
+              color: "#B89490",
+              padding: 0,
+              transition: "color 150ms",
+            }}
+            onMouseEnter={(e) => {
+              (e.target as HTMLButtonElement).style.color = "#7A5550";
+            }}
+            onMouseLeave={(e) => {
+              (e.target as HTMLButtonElement).style.color = "#B89490";
+            }}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </footer>
+  );
+}

--- a/src/app/components/HeroCTA.tsx
+++ b/src/app/components/HeroCTA.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+const CalcIcon = () => (
+  <svg
+    width="22"
+    height="22"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="4" y="2" width="16" height="20" rx="2" />
+    <line x1="8" y1="6" x2="16" y2="6" />
+    <line x1="8" y1="10" x2="10" y2="10" />
+    <line x1="12" y1="10" x2="14" y2="10" />
+    <line x1="16" y1="10" x2="16" y2="10" />
+    <line x1="8" y1="14" x2="10" y2="14" />
+    <line x1="12" y1="14" x2="14" y2="14" />
+    <line x1="16" y1="14" x2="16" y2="14" />
+    <line x1="8" y1="18" x2="16" y2="18" />
+  </svg>
+);
+
+export default function HeroCTA() {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <Link
+      href="/calculator"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "8px",
+        background: "#E07B72",
+        color: "white",
+        fontFamily: "var(--font-dm-sans)",
+        fontSize: "14px",
+        fontWeight: 600,
+        padding: "11px 22px",
+        borderRadius: "8px",
+        textDecoration: "none",
+        boxShadow: hovered
+          ? "0 6px 20px rgba(180,80,60,0.32)"
+          : "0 3px 12px rgba(180,80,60,0.25)",
+        transform: hovered ? "translateY(-1px)" : "translateY(0)",
+        transition: "transform 150ms, box-shadow 150ms",
+      }}
+    >
+      <CalcIcon />
+      Ouvrir la calculatrice
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      >
+        <path d="M3 7h8M7 3l4 4-4 4" />
+      </svg>
+    </Link>
+  );
+}

--- a/src/app/components/NavBar.tsx
+++ b/src/app/components/NavBar.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function NavBar() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 100,
+        background: "rgba(253,246,244,0.85)",
+        backdropFilter: "blur(12px)",
+        borderBottom: "1px solid #EDD9D5",
+        padding: "0 32px",
+        height: "56px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+      }}
+    >
+      <Link
+        href="/"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          textDecoration: "none",
+        }}
+      >
+        <div
+          style={{
+            width: "28px",
+            height: "28px",
+            borderRadius: "7px",
+            background: "#E07B72",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <rect x="1" y="1" width="5" height="5" rx="1" fill="white" />
+            <rect x="8" y="1" width="5" height="5" rx="1" fill="white" opacity="0.7" />
+            <rect x="1" y="8" width="5" height="5" rx="1" fill="white" opacity="0.7" />
+            <rect x="8" y="8" width="5" height="5" rx="1" fill="white" />
+          </svg>
+        </div>
+        <span
+          style={{
+            fontFamily: "var(--font-dm-serif)",
+            fontSize: "17px",
+            color: "#2C1A17",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          Toolbox
+        </span>
+      </Link>
+
+      <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+        <NavLink href="/" active={pathname === "/"}>
+          Outils
+        </NavLink>
+        <NavLink href="#" active={false}>
+          À propos
+        </NavLink>
+      </div>
+    </nav>
+  );
+}
+
+function NavLink({
+  href,
+  active,
+  children,
+}: {
+  href: string;
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      style={{
+        background: active ? "#FEF0ED" : "transparent",
+        fontFamily: "var(--font-dm-sans)",
+        fontSize: "13px",
+        fontWeight: active ? 600 : 400,
+        color: active ? "#C9524A" : "#7A5550",
+        padding: "5px 12px",
+        borderRadius: "6px",
+        textDecoration: "none",
+        transition: "all 150ms",
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/app/components/ToolCard.tsx
+++ b/src/app/components/ToolCard.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type ToolCardProps = {
+  icon: React.ReactNode;
+  name: string;
+  description: string;
+  tag: string;
+  available?: boolean;
+  href?: string;
+};
+
+export default function ToolCard({
+  icon,
+  name,
+  description,
+  tag,
+  available = true,
+  href,
+}: ToolCardProps) {
+  const [hovered, setHovered] = useState(false);
+
+  const cardStyle: React.CSSProperties = {
+    background: "white",
+    border: "1px solid #EDD9D5",
+    borderRadius: "12px",
+    padding: "24px",
+    cursor: available && href ? "pointer" : "default",
+    opacity: available ? 1 : 0.65,
+    transform: hovered && available ? "translateY(-2px)" : "translateY(0)",
+    boxShadow:
+      hovered && available
+        ? "0 8px 24px rgba(180,80,60,0.10), 0 2px 6px rgba(180,80,60,0.06)"
+        : "0 2px 8px rgba(180,80,60,0.06), 0 1px 2px rgba(180,80,60,0.04)",
+    transition:
+      "transform 200ms cubic-bezier(0.25,0,0,1), box-shadow 200ms cubic-bezier(0.25,0,0,1)",
+    textDecoration: "none",
+    display: "block",
+    color: "inherit",
+  };
+
+  const inner = (
+    <>
+      <div
+        style={{
+          width: "44px",
+          height: "44px",
+          borderRadius: "11px",
+          background: available ? "#FEF0ED" : "#F5EAE8",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          marginBottom: "14px",
+          color: available ? "#E07B72" : "#B89490",
+        }}
+      >
+        {icon}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-dm-sans)",
+          fontSize: "15px",
+          fontWeight: 600,
+          color: "#2C1A17",
+          marginBottom: "5px",
+        }}
+      >
+        {name}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-dm-sans)",
+          fontSize: "13px",
+          color: "#7A5550",
+          lineHeight: 1.45,
+          marginBottom: "14px",
+        }}
+      >
+        {description}
+      </div>
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          fontFamily: "var(--font-dm-sans)",
+          fontSize: "10px",
+          fontWeight: 600,
+          letterSpacing: "0.07em",
+          textTransform: "uppercase",
+          background: available ? "#FEF0ED" : "#F5EAE8",
+          color: available ? "#C9524A" : "#9A7672",
+          borderRadius: "4px",
+          padding: "2px 7px",
+        }}
+      >
+        {tag}
+      </span>
+    </>
+  );
+
+  if (available && href) {
+    return (
+      <Link
+        href={href}
+        style={cardStyle}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {inner}
+      </Link>
+    );
+  }
+
+  return (
+    <div
+      style={cardStyle}
+      onMouseEnter={() => available && setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {inner}
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,20 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #FDF6F4;
+  --foreground: #2C1A17;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --font-sans: var(--font-dm-sans);
+  --font-mono: var(--font-jetbrains-mono);
+  --font-serif: var(--font-dm-serif);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-dm-sans), system-ui, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,23 +1,34 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { DM_Sans, DM_Serif_Display, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
+import NavBar from "./components/NavBar";
+import Footer from "./components/Footer";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const dmSans = DM_Sans({
+  variable: "--font-dm-sans",
   subsets: ["latin"],
+  weight: ["300", "400", "500", "600"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const dmSerifDisplay = DM_Serif_Display({
+  variable: "--font-dm-serif",
   subsets: ["latin"],
+  weight: ["400"],
+  style: ["normal", "italic"],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
 });
 
 export const metadata: Metadata = {
   title: {
-    default: "Mes outils front",
-    template: "%s · Mes outils front",
+    default: "Toolbox — Vos outils en ligne",
+    template: "%s · Toolbox",
   },
-  description: "Collection de petits utilitaires web déployés sur Vercel.",
+  description: "Outils simples, résultats clairs. Collection de petits utilitaires web déployés sur Vercel.",
 };
 
 export default function RootLayout({
@@ -28,10 +39,23 @@ export default function RootLayout({
   return (
     <html
       lang="fr"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${dmSans.variable} ${dmSerifDisplay.variable} ${jetbrainsMono.variable} h-full`}
     >
-      <body className="min-h-full flex flex-col bg-zinc-50 dark:bg-black text-zinc-900 dark:text-zinc-100">
-        {children}
+      <body
+        style={{
+          minHeight: "100%",
+          display: "flex",
+          flexDirection: "column",
+          background: "#FDF6F4",
+          color: "#2C1A17",
+          margin: 0,
+        }}
+      >
+        <NavBar />
+        <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+          {children}
+        </div>
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,45 +1,178 @@
-import Link from "next/link";
+import ToolCard from "./components/ToolCard";
+import HeroCTA from "./components/HeroCTA";
 
-type Tool = {
-  href: string;
-  name: string;
-  description: string;
-};
+const CalcIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="4" y="2" width="16" height="20" rx="2" />
+    <line x1="8" y1="6" x2="16" y2="6" />
+    <line x1="8" y1="10" x2="10" y2="10" /><line x1="12" y1="10" x2="14" y2="10" /><line x1="16" y1="10" x2="16" y2="10" />
+    <line x1="8" y1="14" x2="10" y2="14" /><line x1="12" y1="14" x2="14" y2="14" /><line x1="16" y1="14" x2="16" y2="14" />
+    <line x1="8" y1="18" x2="16" y2="18" />
+  </svg>
+);
 
-const tools: Tool[] = [
+const PercentIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+    <circle cx="8" cy="8" r="3" /><circle cx="16" cy="16" r="3" />
+    <line x1="19" y1="5" x2="5" y2="19" />
+  </svg>
+);
+
+const ConvertIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M8 3H5a2 2 0 0 0-2 2v3" /><path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+    <path d="M3 16v3a2 2 0 0 0 2 2h3" /><path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+  </svg>
+);
+
+const TimerIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+    <circle cx="12" cy="13" r="8" /><path d="M12 9v4l2.5 2.5" />
+    <path d="M9.5 3.5h5" /><path d="M12 3.5v2" />
+  </svg>
+);
+
+const tools = [
   {
-    href: "/calculator",
+    id: "calculator",
+    icon: <CalcIcon />,
     name: "Calculatrice",
-    description: "Addition, soustraction, multiplication, division.",
+    description: "Calculs simples et rapides avec historique intégré",
+    tag: "Maths",
+    available: true,
+    href: "/calculator",
+  },
+  {
+    id: "percentage",
+    icon: <PercentIcon />,
+    name: "Pourcentages",
+    description: "Calcul de remises, taxes et variations",
+    tag: "Bientôt",
+    available: false,
+  },
+  {
+    id: "converter",
+    icon: <ConvertIcon />,
+    name: "Conversions",
+    description: "Unités de mesure, températures, devises",
+    tag: "Bientôt",
+    available: false,
+  },
+  {
+    id: "timer",
+    icon: <TimerIcon />,
+    name: "Chronomètre",
+    description: "Minuterie et compteur de temps",
+    tag: "Bientôt",
+    available: false,
   },
 ];
 
 export default function Home() {
   return (
-    <main className="flex-1 flex flex-col items-center px-4 py-12 gap-8">
-      <header className="text-center max-w-2xl">
-        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">
-          Mes outils front
-        </h1>
-        <p className="mt-3 text-zinc-600 dark:text-zinc-400">
-          Une collection de petits utilitaires web déployés sur Vercel.
-        </p>
-      </header>
+    <main style={{ flex: 1 }}>
+      {/* Hero */}
+      <div
+        style={{
+          padding: "64px 32px 52px",
+          maxWidth: "1200px",
+          margin: "0 auto",
+          textAlign: "center",
+        }}
+      >
+        <div
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            fontFamily: "var(--font-dm-sans)",
+            fontSize: "11px",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            background: "#FEF0ED",
+            color: "#E07B72",
+            borderRadius: "4px",
+            padding: "3px 10px",
+            marginBottom: "22px",
+          }}
+        >
+          Outils en ligne
+        </div>
 
-      <section className="w-full max-w-3xl grid gap-4 sm:grid-cols-2">
-        {tools.map((tool) => (
-          <Link
-            key={tool.href}
-            href={tool.href}
-            className="block rounded-2xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-6 shadow-sm hover:shadow-md hover:border-orange-400 dark:hover:border-orange-500 transition"
-          >
-            <h2 className="text-lg font-semibold">{tool.name}</h2>
-            <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-              {tool.description}
-            </p>
-          </Link>
-        ))}
-      </section>
+        <h1
+          style={{
+            fontFamily: "var(--font-dm-serif)",
+            fontSize: "clamp(38px, 5vw, 58px)",
+            fontWeight: 400,
+            lineHeight: 1.08,
+            letterSpacing: "-0.02em",
+            color: "#2C1A17",
+            marginBottom: "16px",
+            maxWidth: "560px",
+            margin: "0 auto 16px",
+          }}
+        >
+          Outils simples,
+          <br />
+          <span style={{ color: "#E07B72", fontStyle: "italic" }}>
+            résultats clairs.
+          </span>
+        </h1>
+
+        <p
+          style={{
+            fontFamily: "var(--font-dm-sans)",
+            fontSize: "16px",
+            color: "#7A5550",
+            lineHeight: 1.55,
+            maxWidth: "380px",
+            margin: "0 auto 36px",
+          }}
+        >
+          Tous vos outils du quotidien, disponibles en un clic.
+        </p>
+
+        <HeroCTA />
+      </div>
+
+      {/* Tools section */}
+      <div style={{ maxWidth: "1200px", margin: "0 auto", padding: "0 32px" }}>
+        <div
+          style={{
+            fontSize: "11px",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "#B89490",
+            marginBottom: "16px",
+            fontFamily: "var(--font-dm-sans)",
+          }}
+        >
+          Tous les outils
+        </div>
+      </div>
+
+      <div style={{ maxWidth: "1200px", margin: "0 auto", padding: "0 32px 96px" }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(3, 1fr)",
+            gap: "16px",
+          }}
+        >
+          {tools.map((tool) => (
+            <ToolCard
+              key={tool.id}
+              icon={tool.icon}
+              name={tool.name}
+              description={tool.description}
+              tag={tool.tag}
+              available={tool.available}
+              href={tool.href}
+            />
+          ))}
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
- New salmon/rose color palette (#E07B72, #FDF6F4) replacing zinc/white
- Fonts: DM Serif Display, DM Sans, JetBrains Mono via next/font/google
- NavBar: sticky, frosted glass, Toolbox brand with grid logo
- Footer: copyright + Confidentialité/Conditions links
- Home page: hero with badge, serif heading, CTA → /calculator, 3-col tool grid (4 tools, 3 coming soon)
- ToolCard: hover lift + shadow, icon badge, tag pill, disabled state
- Calculator: 2-col layout with history sidebar, ±/% keys, fr-FR number formatting

https://claude.ai/code/session_01BsewWy3d9yeh65o7fdHao1