### PR TITLE
feat: add dictation success percentage calculator tool

### DIFF
--- a/src/app/dictation-success/DictationSuccessCalculator.tsx
+++ b/src/app/dictation-success/DictationSuccessCalculator.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function DictationSuccessCalculator() {
+  const [totalWords, setTotalWords] = useState<string>('');
+  const [errors, setErrors] = useState<string>('');
+  const [correctWords, setCorrectWords] = useState<number | null>(null);
+  const [successPercentage, setSuccessPercentage] = useState<number | null>(null);
+
+  const calculate = () => {
+    const total = parseInt(totalWords, 10);
+    const errs = parseInt(errors, 10);
+
+    if (isNaN(total) || isNaN(errs) || total <= 0) {
+      setCorrectWords(null);
+      setSuccessPercentage(null);
+      return;
+    }
+
+    if (errs < 0 || errs > total) {
+      setCorrectWords(null);
+      setSuccessPercentage(null);
+      return;
+    }
+
+    const correct = total - errs;
+    const percentage = (correct / total) * 100;
+
+    setCorrectWords(correct);
+    setSuccessPercentage(percentage);
+  };
+
+  return (
+    <div className="rounded-lg bg-gray-100 p-6 shadow-md">
+      <p className="mb-6 text-sm text-gray-600">
+        Saisissez le nombre total de mots dans la dictée et le nombre d&apos;erreurs pour calculer votre pourcentage de réussite.
+      </p>
+
+      <div className="mb-4">
+        <label className="block text-sm font-medium text-gray-700">
+          Nombre total de mots dans la dictée
+        </label>
+        <input
+          type="number"
+          value={totalWords}
+          onChange={(e) => setTotalWords(e.target.value)}
+          placeholder="Exemple : 50"
+          min="1"
+          className="mt-1 block w-full rounded-md border-gray-300 p-2 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+        />
+      </div>
+
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700">
+          Nombre d&apos;erreurs
+        </label>
+        <input
+          type="number"
+          value={errors}
+          onChange={(e) => setErrors(e.target.value)}
+          placeholder="Exemple : 5"
+          min="0"
+          className="mt-1 block w-full rounded-md border-gray-300 p-2 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+        />
+      </div>
+
+      <button
+        onClick={calculate}
+        className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      >
+        Calculer le pourcentage de réussite
+      </button>
+
+      {(correctWords !== null || successPercentage !== null) && (
+        <div className="mt-6 rounded-md bg-white p-4 shadow-sm">
+          <h3 className="mb-3 text-lg font-semibold text-gray-800">Résultats</h3>
+          
+          <div className="space-y-3">
+            <div>
+              <span className="text-gray-600">Nombre de mots justes : </span>
+              <span className="font-bold text-green-600">{correctWords}</span>
+            </div>
+
+            <div>
+              <span className="text-gray-600">Pourcentage de réussite : </span>
+              <span className="font-bold text-green-600">
+                {successPercentage !== null ? successPercentage.toFixed(2) : '0'}%
+              </span>
+            </div>
+
+            <div className="text-sm text-gray-500">
+              <p>
+                <strong>Calcul :</strong> ({totalWords} mots total - {errors} erreurs = {correctWords} mots justes) → 
+                ({correctWords} / {totalWords}) × 100 = {successPercentage !== null ? successPercentage.toFixed(2) : '0'}%
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dictation-success/page.tsx
+++ b/src/app/dictation-success/page.tsx
@@ -1,0 +1,10 @@
+import DictationSuccessCalculator from "./DictationSuccessCalculator";
+
+export default function DictationSuccessPage() {
+  return (
+    <div className="mx-auto max-w-2xl p-8">
+      <h1 className="mb-6 text-2xl font-bold">Calculateur de pourcentage de réussite pour dictée</h1>
+      <DictationSuccessCalculator />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,16 @@ const PercentIcon = () => (
   </svg>
 );
 
+const DictationIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <path d="M14 2v6h6" />
+    <path d="M16 13H8" />
+    <path d="M16 17H8" />
+    <path d="M10 9H8" />
+  </svg>
+);
+
 const ConvertIcon = () => (
   <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
     <path d="M8 3H5a2 2 0 0 0-2 2v3" /><path d="M21 8V5a2 2 0 0 0-2-2h-3" />
@@ -50,6 +60,15 @@ const tools = [
     tag: "Maths",
     available: true,
     href: "/percentage",
+  },
+  {
+    id: "dictation-success",
+    icon: <DictationIcon />,
+    name: "Pourcentage de réussite",
+    description: "Calculez votre score de dictée : mots justes et pourcentage de réussite",
+    tag: "Éducation",
+    available: true,
+    href: "/dictation-success",
   },
   {
     id: "converter",


### PR DESCRIPTION
## Description

Ajout d'un nouvel outil pour calculer le pourcentage de réussite d'une dictée.

## Changements

- **Nouvelle page** :  avec le composant 
- **Intégration homepage** : Ajout d'une carte outil avec icône dédiée
- **Fonctionnalités** :
  - Saisie du nombre total de mots dans la dictée
  - Saisie du nombre d'erreurs
  - Affichage du nombre de mots justes
  - Affichage du pourcentage de réussite
  - Affichage transparent de la formule de calcul

## Capture d'écran

![Dictation Success Calculator](https://via.placeholder.com/600x400?text=Dictation+Success+Calculator)

## Issue

Closes #8