### PR TITLE
fix(workflows): align Mistral secrets, enforce JSON response format, improve error handling

### DIFF
--- a/.github/workflows/po-agent-manual-v2.yml
+++ b/.github/workflows/po-agent-manual-v2.yml
@@ -58,11 +58,8 @@ jobs:
               "   - Risque technique (dette technique, securite, scalabilite).",
               "   - Effort de correction (privilégie les quick wins si impact equivalent).",
               "2. Sois specifique : L issue doit etre actionnable (pas de ameliorer la doc, mais ajouter des exemples dans la doc de l API /users).",
-              "3. Format de sortie : UNIQUEMENT ce JSON (pas de texte avant/apres) :",
-              "   title: string (max 50 caracteres)",
-              "   body: string avec Contexte, Impact, Solution proposee, Criteres d acceptation",
-              "   priority: low|medium|high|critical",
-              "   labels: array de max 3 strings"
+              "3. Format de sortie : UNIQUEMENT un JSON valide, sans texte avant/apres, sans markdown, sans backticks :",
+              '   { "title": string (max 50 caracteres), "body": string avec Contexte, Impact, Solution proposee, Criteres d acceptation, "priority": "low|medium|high|critical", "labels": array de max 3 strings }'
             ].join("\n");
 
             const userPrompt = `Analyse le projet GitHub suivant : ${repository}. ${poPrompt}`;
@@ -75,8 +72,15 @@ jobs:
               },
               body: JSON.stringify({
                 model: "mistral-large-latest",
-                messages: [{ role: 'user', content: userPrompt }],
-                temperature: 0.3
+                messages: [
+                  {
+                    role: 'system',
+                    content: 'You MUST respond with a valid JSON object only. No markdown, no explanation, no backticks. Use this exact format: { "title": string, "body": string, "priority": "low|medium|high|critical", "labels": string[] }'
+                  },
+                  { role: 'user', content: userPrompt }
+                ],
+                temperature: 0.3,
+                response_format: { type: 'json_object' }
               })
             });
 
@@ -103,8 +107,8 @@ jobs:
                 });
                 core.info('Issue created successfully!');
               } else {
-                core.warning('Valid response but incomplete JSON format.');
+                core.setFailed('Mistral response is missing required fields (title, body). Response: ' + content);
               }
             } catch (e) {
-              core.warning('Invalid JSON format in response: ' + e.message);
+              core.setFailed('Invalid JSON format in Mistral response: ' + e.message + '. Response was: ' + content);
             }

--- a/.github/workflows/po-agent-manual.yml
+++ b/.github/workflows/po-agent-manual.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-          MISTRAL_MODEL_ID: ${{ secrets.MISTRAL_API_ID_PO }}
+          MISTRAL_MODEL_ID: ${{ secrets.MISTRAL_MODEL_ID }}
         with:
           script: |
             const prompt = `${{ github.event.inputs.prompt }}`;
@@ -34,15 +34,22 @@ jobs:
                 'Authorization': authHeader
               },
               body: JSON.stringify({
-                model: process.env.MISTRAL_MODEL_ID,
-                messages: [{ role: 'user', content: prompt }],
-                temperature: 0.3
+                model: process.env.MISTRAL_MODEL_ID || 'mistral-large-latest',
+                messages: [
+                  {
+                    role: 'system',
+                    content: 'You MUST respond with a valid JSON object only. No markdown, no explanation. Use this exact format: { "title": string, "body": string, "priority": "low|medium|high|critical", "labels": string[] }'
+                  },
+                  { role: 'user', content: prompt }
+                ],
+                temperature: 0.3,
+                response_format: { type: 'json_object' }
               })
             });
 
             if (!mistralResponse.ok) {
               const errorDetails = await mistralResponse.text();
-              core.setFailed(`Mistral API error: ${mistralResponse.status} - ${errorDetails}. Vérifiez que MISTRAL_API_KEY est configuré.`);
+              core.setFailed(`Mistral API error: ${mistralResponse.status} - ${errorDetails}. Vérifiez que MISTRAL_API_KEY et MISTRAL_MODEL_ID sont configurés.`);
               return;
             }
 
@@ -53,7 +60,7 @@ jobs:
             try {
               const issueData = JSON.parse(content);
               if (issueData.title && issueData.body) {
-                const labels = issueData.labels || ['enhancement', 'needs-mistral'];
+                const labels = issueData.labels || ['enhancement'];
                 await github.rest.issues.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -63,8 +70,8 @@ jobs:
                 });
                 core.info('Issue created successfully!');
               } else {
-                core.warning('Valid response but incomplete JSON format.');
+                core.setFailed('Mistral response is missing required fields (title, body). Response: ' + content);
               }
             } catch (e) {
-              core.warning('Invalid JSON format in response.');
+              core.setFailed('Invalid JSON format in Mistral response: ' + e.message + '. Response was: ' + content);
             }


### PR DESCRIPTION
## Fixes pour les workflows Mistral PO Agent

### Problèmes résolus
- Secret mal nommé dans po-agent-manual.yml: MISTRAL_API_ID_PO -> MISTRAL_MODEL_ID
- Réponse Mistral non-JSON: ajout de response_format: json_object + system prompt
- Erreurs silencieuses: remplacement de core.warning par core.setFailed

### Actions requises après merge
1. Vérifier que les secrets MISTRAL_API_KEY et MISTRAL_MODEL_ID existent
2. Renommer MISTRAL_API_ID_PO en MISTRAL_MODEL_ID si nécessaire

### Test
Lancer manuellement les 2 workflows pour valider que les issues sont créées correctement.