### PR TITLE
Refactor Mistral/PO workflows into reusable workflows + po-* naming

### DIFF
--- a/.github/workflows/po-clarified.yml
+++ b/.github/workflows/po-clarified.yml
@@ -1,4 +1,4 @@
-name: Handle Clarification OK Label
+name: PO - Handle Clarification OK Label
 
 on:
   issues:
@@ -7,6 +7,6 @@ on:
 jobs:
   call:
     if: github.event.label.name == 'clarification-ok' && contains(github.event.issue.labels.*.name, 'clarification-ok')
-    uses: ./.github/workflows/reusable-clarification-ok-handler.yml
+    uses: ./.github/workflows/reusable-po-clarified.yml
     secrets:
       MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}

--- a/.github/workflows/po-create-issue.yml
+++ b/.github/workflows/po-create-issue.yml
@@ -1,4 +1,4 @@
-name: PO Agent
+name: PO - Create Issue
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.issue.labels.*.name, 'po-generated')
-    uses: ./.github/workflows/reusable-po-agent.yml
+    uses: ./.github/workflows/reusable-po-create-issue.yml
     with:
       repository: ${{ github.event.inputs.repository || github.repository }}
       custom_prompt: ${{ github.event.inputs.prompt || '' }}

--- a/.github/workflows/po-labels.yml
+++ b/.github/workflows/po-labels.yml
@@ -1,4 +1,4 @@
-name: Create Required Labels
+name: PO - Create Required Labels
 
 on:
   workflow_dispatch:
@@ -9,4 +9,4 @@ on:
 
 jobs:
   call:
-    uses: ./.github/workflows/reusable-create-labels.yml
+    uses: ./.github/workflows/reusable-po-labels.yml

--- a/.github/workflows/po-question.yml
+++ b/.github/workflows/po-question.yml
@@ -1,4 +1,4 @@
-name: Handle Question Label
+name: PO - Handle Question Label
 
 on:
   issues:
@@ -7,6 +7,6 @@ on:
 jobs:
   call:
     if: github.event.label.name == 'question'
-    uses: ./.github/workflows/reusable-question-handler.yml
+    uses: ./.github/workflows/reusable-po-question.yml
     secrets:
       MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}

--- a/.github/workflows/po-rewrite.yml
+++ b/.github/workflows/po-rewrite.yml
@@ -1,4 +1,4 @@
-name: Generate Rewrite Proposal with Mistral
+name: PO - Generate Rewrite Proposal with Mistral
 
 on:
   issues:
@@ -7,6 +7,6 @@ on:
 jobs:
   call:
     if: github.event.label.name == 'needs-mistral'
-    uses: ./.github/workflows/reusable-mistral-generator.yml
+    uses: ./.github/workflows/reusable-po-rewrite.yml
     secrets:
       MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}

--- a/.github/workflows/reusable-po-clarified.yml
+++ b/.github/workflows/reusable-po-clarified.yml
@@ -1,4 +1,4 @@
-name: Reusable - Handle Clarification OK Label
+name: Reusable - PO Clarification Handler
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-po-create-issue.yml
+++ b/.github/workflows/reusable-po-create-issue.yml
@@ -1,4 +1,4 @@
-name: Reusable - PO Agent
+name: Reusable - PO Create Issue
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-po-labels.yml
+++ b/.github/workflows/reusable-po-labels.yml
@@ -1,4 +1,4 @@
-name: Reusable - Create Required Labels
+name: Reusable - PO Labels
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-po-question.yml
+++ b/.github/workflows/reusable-po-question.yml
@@ -1,4 +1,4 @@
-name: Reusable - Handle Question Label
+name: Reusable - PO Question Handler
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-po-rewrite.yml
+++ b/.github/workflows/reusable-po-rewrite.yml
@@ -1,4 +1,4 @@
-name: Reusable - Generate Rewrite Proposal with Mistral
+name: Reusable - PO Rewrite Generator
 
 on:
   workflow_call:

--- a/PO_BRIEF.md
+++ b/PO_BRIEF.md
@@ -415,6 +415,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 2026-05-06 | **Unification sur Tailwind CSS** | Cohérence du design, maintenance simplifiée | PO |
 | 2026-05-18 | **Refactor des workflows en reusable workflows** | Réutilisabilité de l'automatisation Mistral/PO sur tout projet (export V1 ultérieur) | PO |
 | 2026-05-18 | **Plafond de 2 issues PO ouvertes + chaîne auto + anti-doublon** | Limiter la file de validation ; label dédié `po-generated` | PO |
+| 2026-05-18 | **Convention de nommage `po-*` / `reusable-po-*`** | Nommage clair et cohérent des workflows (fin des suffixes `_handler`/`-v2`) | PO |
 
 ### **Questions Ouvertes**
 1. **Faut-il ajouter un backend ?**
@@ -440,6 +441,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 |---------|------|--------|-------------|
 | 1.0 | 2026-05-06 | [Votre Nom] | Création initiale du document |
 | 1.1 | 2026-05-18 | Coding Agent | Refactor workflows en reusable workflows ; nouvelle politique PO Agent (max 2 issues `po-generated`, chaîne auto, anti-doublon) |
+| 1.2 | 2026-05-18 | Coding Agent | Convention de nommage `po-*` / `reusable-po-*` pour tous les workflows |
 
 ---
 


### PR DESCRIPTION
## Summary
- Refactor des 6 workflows Mistral/PO en **reusable workflows** (`workflow_call`) + callers minces, paramétrés via inputs/secrets — réutilisables sur tout projet, exportables en V1 plus tard.
- Nouvelle politique **PO Agent** : plafond de **2 issues `po-generated` ouvertes** (garde de seuil), **chaîne auto** (relance sur `issues: opened/closed`), **anti-doublon** (issues ouvertes injectées dans le prompt), label dédié `po-generated`.
- Convention de nommage cohérente : callers `po-*.yml`, logique `reusable-po-*.yml` (fin des suffixes `_handler` / `-v2`).
- `PO_BRIEF.md` mis à jour (Notes & Décisions, Historique des Versions).

## Workflows
| Rôle | Caller | Reusable |
|---|---|---|
| Création d'issue PO (manuel) | `po-create-issue.yml` | `reusable-po-create-issue.yml` |
| Issue `question` | `po-question.yml` | `reusable-po-question.yml` |
| Réécriture Mistral | `po-rewrite.yml` | `reusable-po-rewrite.yml` |
| Validation `clarification-ok` | `po-clarified.yml` | `reusable-po-clarified.yml` |
| Labels | `po-labels.yml` | `reusable-po-labels.yml` |

## ⚠️ Configuration requise
- Secret **`PO_TRIGGER_TOKEN`** (PAT portée `repo`) : indispensable à la chaîne auto — GitHub ne ré-enchaîne pas les workflows sur les issues créées via le `GITHUB_TOKEN` par défaut. Sans lui, seul le lancement manuel fonctionne.
- Secret `MISTRAL_API_KEY` (déjà utilisé).

## Test plan
- [ ] Lancer `PO - Create Required Labels` → vérifier les labels (dont `po-generated`)
- [ ] Configurer `PO_TRIGGER_TOKEN`
- [ ] Lancer `PO - Create Issue` avec 0 issue PO → 1 issue créée ; chaîne → 2 ; 3e run = no-op (seuil)
- [ ] Vérifier l'absence de doublon sur la 2e proposition
- [ ] Fermer une issue PO → ré-armement, recréation d'1 issue
- [ ] Chaîne labels `question` → `clarification-ok` → `development`, retrait de `po-generated`

https://claude.ai/code/session_01MXonTLbnbpRUxBfxJUHuRj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXonTLbnbpRUxBfxJUHuRj)_