### PR TITLE
po-autocreate: 1 issue par run + auto-relance via PAT jusqu'à maxOpen

### DIFF
--- a/.github/workflows/po-autocreate.yml
+++ b/.github/workflows/po-autocreate.yml
@@ -1,11 +1,15 @@
 name: PO - Autocreate Issues
 
-# Création automatique d'issues `po-generated`.
+# Création automatique d'issues `po-generated`, UNE seule par run.
 # - workflow_dispatch : premier lancement manuel.
 # - issues: [closed]   : quand vous fermez/validez une issue po-generated,
-#   l'événement (action humaine) relance le workflow qui recomplète jusqu'à 2.
-# Pas de PAT : le GITHUB_TOKEN ne peut pas s'auto-relancer, donc un seul run
-# BOUCLE et crée des issues jusqu'à atteindre max_open.
+#   l'événement (action humaine) relance le workflow.
+# Après avoir créé 1 issue, si le plafond n'est pas atteint, le run attend
+# ~90 s puis se relance lui-même via l'API workflow_dispatch en utilisant le
+# PAT `PO_DISPATCH_TOKEN` (le GITHUB_TOKEN par défaut ne peut pas s'auto-
+# relancer). Chaque run recompte l'état réel des issues en cours, ce qui
+# évite les doublons et tient compte des issues en cours de traitement.
+# Sans PO_DISPATCH_TOKEN : pas d'auto-relance, 1 issue par déclenchement.
 
 on:
   workflow_dispatch:
@@ -33,6 +37,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          PO_DISPATCH_TOKEN: ${{ secrets.PO_DISPATCH_TOKEN }}
         with:
           script: |
             const fs = require('fs');
@@ -41,7 +46,7 @@ jobs:
             const poLabel = 'po-generated';
             const maxOpen = 2;
             const model = 'mistral-large-latest';
-            const MAX_ITER = 5;
+            const relaunchDelayMs = 90000;
 
             const buildPrompt = require(
               path.join(process.env.GITHUB_WORKSPACE, '.github/prompts/autocreate.js'));
@@ -73,87 +78,126 @@ jobs:
               core.warning('PO_BRIEF.md not found, continuing without it.');
             }
 
-            for (let iter = 0; iter < MAX_ITER; iter++) {
-              const openPoIssues = await github.paginate(github.rest.issues.listForRepo, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                labels: poLabel,
-                per_page: 100
-              });
-              const realIssues = openPoIssues.filter(i => !i.pull_request);
-              core.info(`Open '${poLabel}' issues: ${realIssues.length} / max ${maxOpen}`);
-              if (realIssues.length >= maxOpen) {
-                core.info('Threshold reached, stopping.');
-                break;
-              }
+            // 1 issue par run : on compte l'état réel, on en crée AU PLUS une.
+            const openPoIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: poLabel,
+              per_page: 100
+            });
+            const realIssues = openPoIssues.filter(i => !i.pull_request);
+            core.info(`Open '${poLabel}' issues: ${realIssues.length} / max ${maxOpen}`);
+            if (realIssues.length >= maxOpen) {
+              core.info('Threshold reached, nothing to create and no relaunch.');
+              return;
+            }
 
-              const allOpen = await github.paginate(github.rest.issues.listForRepo, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: 'open',
-                per_page: 100
-              });
-              const existingIssuesBlock = allOpen
-                .filter(i => !i.pull_request)
-                .map(i => `- #${i.number} ${i.title}\n  ${(i.body || '').replace(/\s+/g, ' ').slice(0, 300)}`)
-                .join('\n');
+            const allOpen = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+            const existingIssuesBlock = allOpen
+              .filter(i => !i.pull_request)
+              .map(i => `- #${i.number} ${i.title}\n  ${(i.body || '').replace(/\s+/g, ' ').slice(0, 300)}`)
+              .join('\n');
 
-              const userPrompt = buildPrompt(
-                `${context.repo.owner}/${context.repo.repo}`, briefContent, existingIssuesBlock);
+            const userPrompt = buildPrompt(
+              `${context.repo.owner}/${context.repo.repo}`, briefContent, existingIssuesBlock);
 
-              const mistralResponse = await fetch('https://api.mistral.ai/v1/chat/completions', {
+            const mistralResponse = await fetch('https://api.mistral.ai/v1/chat/completions', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer ' + process.env.MISTRAL_API_KEY
+              },
+              body: JSON.stringify({
+                model,
+                messages: [
+                  {
+                    role: 'system',
+                    content: 'You MUST respond with a valid JSON object only. No markdown, no explanation, no backticks. Use this exact format: { "title": string, "body": string, "priority": "low|medium|high|critical", "labels": string[] }'
+                  },
+                  { role: 'user', content: userPrompt }
+                ],
+                temperature: 0.3,
+                response_format: { type: 'json_object' }
+              })
+            });
+
+            if (!mistralResponse.ok) {
+              const errorDetails = await mistralResponse.text();
+              core.setFailed(`Mistral API error: ${mistralResponse.status} - ${errorDetails}. Vérifiez que MISTRAL_API_KEY est configuré.`);
+              return;
+            }
+
+            const data = await mistralResponse.json();
+            const content = data.choices[0].message.content;
+            core.info('Mistral response: ' + content);
+
+            let issueData;
+            try {
+              issueData = JSON.parse(content);
+            } catch (e) {
+              core.setFailed('Invalid JSON format in Mistral response: ' + e.message + '. Response was: ' + content);
+              return;
+            }
+            if (!issueData.title || !issueData.body) {
+              core.setFailed('Mistral response is missing required fields (title, body). Response: ' + content);
+              return;
+            }
+
+            const labels = Array.from(new Set([
+              ...(Array.isArray(issueData.labels) ? issueData.labels : ['enhancement']),
+              poLabel
+            ]));
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: issueData.title,
+              body: issueData.body,
+              labels
+            });
+            core.info(`Created issue #${created.data.number} with label ${poLabel}.`);
+
+            // Auto-relance jusqu'à maxOpen, en tenant compte des issues en cours.
+            const remaining = maxOpen - (realIssues.length + 1);
+            if (remaining <= 0) {
+              core.info('maxOpen atteint après cette issue, pas de relance.');
+              return;
+            }
+
+            const dispatchToken = process.env.PO_DISPATCH_TOKEN;
+            if (!dispatchToken) {
+              core.warning(
+                'PO_DISPATCH_TOKEN absent : auto-relance désactivée. ' +
+                'Ajoutez un PAT (Actions: read/write) en secret pour ' +
+                'recompléter automatiquement jusqu\'à ' + maxOpen + ' issues.');
+              return;
+            }
+
+            core.info(`Encore ${remaining} issue(s) à créer, pause ~${relaunchDelayMs / 1000}s avant relance.`);
+            await new Promise(r => setTimeout(r, relaunchDelayMs));
+
+            const ref = (context.payload.repository && context.payload.repository.default_branch) || 'main';
+            const dispatchResp = await fetch(
+              `https://api.github.com/repos/${context.repo.owner}/${context.repo.repo}/actions/workflows/po-autocreate.yml/dispatches`,
+              {
                 method: 'POST',
                 headers: {
-                  'Content-Type': 'application/json',
-                  'Authorization': 'Bearer ' + process.env.MISTRAL_API_KEY
+                  'Accept': 'application/vnd.github+json',
+                  'Authorization': 'Bearer ' + dispatchToken,
+                  'X-GitHub-Api-Version': '2022-11-28',
+                  'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({
-                  model,
-                  messages: [
-                    {
-                      role: 'system',
-                      content: 'You MUST respond with a valid JSON object only. No markdown, no explanation, no backticks. Use this exact format: { "title": string, "body": string, "priority": "low|medium|high|critical", "labels": string[] }'
-                    },
-                    { role: 'user', content: userPrompt }
-                  ],
-                  temperature: 0.3,
-                  response_format: { type: 'json_object' }
-                })
+                body: JSON.stringify({ ref })
               });
 
-              if (!mistralResponse.ok) {
-                const errorDetails = await mistralResponse.text();
-                core.setFailed(`Mistral API error: ${mistralResponse.status} - ${errorDetails}. Vérifiez que MISTRAL_API_KEY est configuré.`);
-                return;
-              }
-
-              const data = await mistralResponse.json();
-              const content = data.choices[0].message.content;
-              core.info('Mistral response: ' + content);
-
-              let issueData;
-              try {
-                issueData = JSON.parse(content);
-              } catch (e) {
-                core.setFailed('Invalid JSON format in Mistral response: ' + e.message + '. Response was: ' + content);
-                return;
-              }
-              if (!issueData.title || !issueData.body) {
-                core.setFailed('Mistral response is missing required fields (title, body). Response: ' + content);
-                return;
-              }
-
-              const labels = Array.from(new Set([
-                ...(Array.isArray(issueData.labels) ? issueData.labels : ['enhancement']),
-                poLabel
-              ]));
-              const created = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: issueData.title,
-                body: issueData.body,
-                labels
-              });
-              core.info(`Created issue #${created.data.number} with label ${poLabel}.`);
+            if (!dispatchResp.ok) {
+              const errBody = await dispatchResp.text();
+              core.setFailed(`Auto-relance échouée: ${dispatchResp.status} - ${errBody}. Vérifiez le scope du PAT PO_DISPATCH_TOKEN.`);
+              return;
             }
+            core.info(`Workflow relancé sur ${ref} pour créer la/les issue(s) restante(s).`);

--- a/PO_BRIEF.md
+++ b/PO_BRIEF.md
@@ -418,6 +418,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 2026-05-18 | **Convention de nommage `po-*` / `reusable-po-*`** | Nommage clair et cohérent des workflows (fin des suffixes `_handler`/`-v2`) | PO |
 | 2026-05-18 | **Correction du prompt de réécriture (`reusable-po-rewrite.yml`)** | Le prompt ignorait titre/description/réponses de l'issue : injection du contexte complet (issue + échanges de clarification) pour une réécriture pertinente | Coding Agent |
 | 2026-05-18 | **Rebuild en 2 workflows (`po-autocreate.yml`, `po-clarify.yml`)** | Simplification : `MISTRAL_API_KEY` seul secret, prompts externalisés dans `.github/prompts/`, suppression de tous les `reusable-po-*.yml`, de `PO_TRIGGER_TOKEN` et `MISTRAL_MODEL_ID` | Coding Agent |
+| 2026-05-18 | **1 issue par run + auto-relance via PAT `PO_DISPATCH_TOKEN`** | `po-autocreate.yml` ne crée plus qu'une issue par run puis se relance (workflow_dispatch via PAT) après une pause ~90 s jusqu'à `maxOpen`, afin que chaque création tienne compte de l'état réel des issues en cours (anti-doublon, clarify/rewrite, actions humaines). Sans le PAT : 1 issue par déclenchement, pas d'auto-relance | Coding Agent |
 
 ### **Questions Ouvertes**
 1. **Faut-il ajouter un backend ?**
@@ -429,11 +430,14 @@ Utilisez ce tableau pour évaluer chaque proposition :
    - *Options* : Publicité (non intrusive), donations, modèle freemium
    - **Décision** : À discuter (priorité à la croissance utilisateur)
 
-3. ~~**Secret `PO_TRIGGER_TOKEN` (PAT) requis pour la chaîne auto du PO Agent**~~
-   - **Résolu (2026-05-18)** : le rebuild en 2 workflows supprime ce besoin.
-     `po-autocreate.yml` boucle dans un seul run jusqu'au seuil de 2 issues,
-     et se relance sur `issues: [closed]` (action humaine). Plus de PAT requis :
-     seul `MISTRAL_API_KEY` est nécessaire.
+3. **Secret `PO_DISPATCH_TOKEN` (PAT) pour l'auto-relance du PO Agent**
+   - **Décision (2026-05-18)** : `po-autocreate.yml` crée 1 issue par run puis
+     se relance via `workflow_dispatch` (API) après ~90 s, jusqu'à `maxOpen`.
+     Le `GITHUB_TOKEN` par défaut ne peut pas s'auto-déclencher : un PAT en
+     secret `PO_DISPATCH_TOKEN` (scope Actions: read/write) est requis pour
+     l'auto-relance. Sans ce secret : 1 issue par déclenchement (manuel ou
+     fermeture d'une issue `po-generated`), sans recomplétion automatique.
+     `MISTRAL_API_KEY` reste requis pour la génération.
 
 ---
 
@@ -446,6 +450,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 1.2 | 2026-05-18 | Coding Agent | Convention de nommage `po-*` / `reusable-po-*` pour tous les workflows |
 | 1.3 | 2026-05-18 | Coding Agent | Fix : `reusable-po-rewrite.yml` injecte désormais le titre, la description et les commentaires (questions/réponses) dans le prompt Mistral |
 | 1.4 | 2026-05-18 | Coding Agent | Rebuild en 2 workflows (`po-autocreate.yml`, `po-clarify.yml`) ; `MISTRAL_API_KEY` seul secret ; prompts externalisés (`autocreate.js`, `questions.js`, `rewrite.js`) ; suppression des `reusable-po-*.yml`, `PO_TRIGGER_TOKEN`, `MISTRAL_MODEL_ID`, `po-prompt.js`, labels `needs-mistral`/`needs-clarification` |
+| 1.5 | 2026-05-18 | Coding Agent | `po-autocreate.yml` : 1 issue par run + auto-relance via PAT `PO_DISPATCH_TOKEN` (workflow_dispatch, pause ~90 s) jusqu'à `maxOpen` ; suppression de la boucle interne `MAX_ITER` ; chaque run recompte l'état réel des issues en cours |
 
 ---
 


### PR DESCRIPTION
Supprime la boucle interne MAX_ITER : chaque run crée au plus une issue po-generated puis, si le plafond n'est pas atteint, attend ~90 s et se relance via workflow_dispatch (PAT PO_DISPATCH_TOKEN). Chaque run recompte l'état réel des issues, pour tenir compte des issues en cours et éviter les doublons. Sans PO_DISPATCH_TOKEN : 1 issue par déclenchement.

https://claude.ai/code/session_018P2qBsSCU4k3egcoLqdciw