### PR TITLE
feat(dictation-success): calcul dynamique du pourcentage de réussite (sans bouton)

### DIFF
--- a/PO_BRIEF.md
+++ b/PO_BRIEF.md
@@ -200,14 +200,14 @@ User → Next.js App Router → Composant Outil → État Local (useState) → A
 
 ### **3. Pourcentage de Réussite (`/dictation-success`)**
 **Fonctionnalités** :
-- Calcul du nombre de mots justes (total - erreurs)
-- Calcul du pourcentage de réussite
-- Affichage détaillé du calcul
+- Calcul **automatique** du nombre de mots justes (total - erreurs) dès la saisie (sans bouton)
+- Calcul **réactif** du pourcentage de réussite dès que les deux champs sont valides
+- Affichage détaillé du calcul (format `X.XX %`)
+- Messages d'erreur contextuels (champ invalide, total ≤ 0, erreurs hors plage)
+- Accessibilité : résultat/erreur annoncés via `aria-live` (+ `role="alert"`)
 
 **Points à Améliorer** :
 - **Design incohérent** : Même problème que l'outil Pourcentages (Tailwind vs custom)
-- **Logique métier** : Ne gère pas les cas où `erreurs > total` (à corriger)
-- **Expérience utilisateur** : Pas de validation en temps réel
 
 ---
 
@@ -446,8 +446,9 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 1.2 | 2026-05-18 | Coding Agent | Convention de nommage `po-*` / `reusable-po-*` pour tous les workflows |
 | 1.3 | 2026-05-18 | Coding Agent | Fix : `reusable-po-rewrite.yml` injecte désormais le titre, la description et les commentaires (questions/réponses) dans le prompt Mistral |
 | 1.4 | 2026-05-18 | Coding Agent | Rebuild en 2 workflows (`po-autocreate.yml`, `po-clarify.yml`) ; `MISTRAL_API_KEY` seul secret ; prompts externalisés (`autocreate.js`, `questions.js`, `rewrite.js`) ; suppression des `reusable-po-*.yml`, `PO_TRIGGER_TOKEN`, `MISTRAL_MODEL_ID`, `po-prompt.js`, labels `needs-mistral`/`needs-clarification` |
+| 1.5 | 2026-05-29 | Coding Agent | Calcul dynamique du pourcentage de réussite (`/dictation-success`) : suppression du bouton « Calculer », calcul réactif dérivé des champs, messages d'erreur contextuels et `aria-live` (issue #11) |
 
 ---
 
 *Document généré automatiquement à partir de l'analyse du dépôt [Manidrim/my-utils-for-versel](https://github.com/Manidrim/my-utils-for-versel).*
-*Dernière mise à jour : 2026-05-18.*
+*Dernière mise à jour : 2026-05-29.*

--- a/src/app/dictation-success/DictationSuccessCalculator.tsx
+++ b/src/app/dictation-success/DictationSuccessCalculator.tsx
@@ -2,39 +2,52 @@
 
 import { useState } from 'react';
 
+type Calculation =
+  | { status: 'empty' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; correctWords: number; successPercentage: number };
+
+function computeResult(totalWords: string, errors: string): Calculation {
+  // Tant que les deux champs ne sont pas remplis, on n'affiche ni résultat ni erreur.
+  if (totalWords.trim() === '' || errors.trim() === '') {
+    return { status: 'empty' };
+  }
+
+  const total = parseInt(totalWords, 10);
+  const errs = parseInt(errors, 10);
+
+  if (isNaN(total) || isNaN(errs)) {
+    return { status: 'error', message: 'Veuillez entrer des nombres valides.' };
+  }
+
+  if (total <= 0) {
+    return { status: 'error', message: 'Le nombre total de mots doit être supérieur à zéro.' };
+  }
+
+  if (errs < 0 || errs > total) {
+    return {
+      status: 'error',
+      message: "Le nombre d'erreurs doit être compris entre 0 et le nombre total de mots.",
+    };
+  }
+
+  const correctWords = total - errs;
+  const successPercentage = (correctWords / total) * 100;
+
+  return { status: 'success', correctWords, successPercentage };
+}
+
 export default function DictationSuccessCalculator() {
   const [totalWords, setTotalWords] = useState<string>('');
   const [errors, setErrors] = useState<string>('');
-  const [correctWords, setCorrectWords] = useState<number | null>(null);
-  const [successPercentage, setSuccessPercentage] = useState<number | null>(null);
 
-  const calculate = () => {
-    const total = parseInt(totalWords, 10);
-    const errs = parseInt(errors, 10);
-
-    if (isNaN(total) || isNaN(errs) || total <= 0) {
-      setCorrectWords(null);
-      setSuccessPercentage(null);
-      return;
-    }
-
-    if (errs < 0 || errs > total) {
-      setCorrectWords(null);
-      setSuccessPercentage(null);
-      return;
-    }
-
-    const correct = total - errs;
-    const percentage = (correct / total) * 100;
-
-    setCorrectWords(correct);
-    setSuccessPercentage(percentage);
-  };
+  // Le résultat est dérivé des champs : il se met à jour automatiquement à chaque saisie.
+  const result = computeResult(totalWords, errors);
 
   return (
     <div className="rounded-lg bg-gray-100 p-6 shadow-md">
       <p className="mb-6 text-sm text-gray-600">
-        Saisissez le nombre total de mots dans la dictée et le nombre d&apos;erreurs pour calculer votre pourcentage de réussite.
+        Saisissez le nombre total de mots dans la dictée et le nombre d&apos;erreurs : le pourcentage de réussite se calcule automatiquement.
       </p>
 
       <div className="mb-4">
@@ -65,39 +78,40 @@ export default function DictationSuccessCalculator() {
         />
       </div>
 
-      <button
-        onClick={calculate}
-        className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-      >
-        Calculer le pourcentage de réussite
-      </button>
+      <div aria-live="polite">
+        {result.status === 'error' && (
+          <div className="rounded-md bg-red-50 p-4 text-sm font-medium text-red-700 shadow-sm" role="alert">
+            {result.message}
+          </div>
+        )}
 
-      {(correctWords !== null || successPercentage !== null) && (
-        <div className="mt-6 rounded-md bg-white p-4 shadow-sm">
-          <h3 className="mb-3 text-lg font-semibold text-gray-800">Résultats</h3>
-          
-          <div className="space-y-3">
-            <div>
-              <span className="text-gray-600">Nombre de mots justes : </span>
-              <span className="font-bold text-green-600">{correctWords}</span>
-            </div>
+        {result.status === 'success' && (
+          <div className="rounded-md bg-white p-4 shadow-sm">
+            <h3 className="mb-3 text-lg font-semibold text-gray-800">Résultats</h3>
 
-            <div>
-              <span className="text-gray-600">Pourcentage de réussite : </span>
-              <span className="font-bold text-green-600">
-                {successPercentage !== null ? successPercentage.toFixed(2) : '0'}%
-              </span>
-            </div>
+            <div className="space-y-3">
+              <div>
+                <span className="text-gray-600">Nombre de mots justes : </span>
+                <span className="font-bold text-green-600">{result.correctWords}</span>
+              </div>
 
-            <div className="text-sm text-gray-500">
-              <p>
-                <strong>Calcul :</strong> ({totalWords} mots total - {errors} erreurs = {correctWords} mots justes) → 
-                ({correctWords} / {totalWords}) × 100 = {successPercentage !== null ? successPercentage.toFixed(2) : '0'}%
-              </p>
+              <div>
+                <span className="text-gray-600">Pourcentage de réussite : </span>
+                <span className="font-bold text-green-600">
+                  {result.successPercentage.toFixed(2)} %
+                </span>
+              </div>
+
+              <div className="text-sm text-gray-500">
+                <p>
+                  <strong>Calcul :</strong> ({totalWords} mots total - {errors} erreurs = {result.correctWords} mots justes) →
+                  ({result.correctWords} / {totalWords}) × 100 = {result.successPercentage.toFixed(2)} %
+                </p>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Contexte

Résout l'issue #11 : rendre le calcul du pourcentage de réussite (outil dictée, `/dictation-success`) **réactif** et instantané, sans bouton « Calculer ».

## Changements

- **Suppression du bouton « Calculer »** : le calcul se déclenche automatiquement dès la saisie/modification des champs.
- **Résultat dérivé des champs** (fonction `computeResult`) plutôt que stocké en state via un effet — conforme à la règle React/Next `react-hooks/set-state-in-effect` et au principe « You Might Not Need an Effect ».
- **Logique métier inchangée** : `pourcentage = (mots justes / total) * 100`, avec `mots justes = total - erreurs`.
- **Calcul déclenché uniquement si les deux champs sont valides** (nombres, total > 0, `0 ≤ erreurs ≤ total`).
- **Messages d'erreur contextuels** :
  - nombres invalides → « Veuillez entrer des nombres valides. »
  - total ≤ 0 → « Le nombre total de mots doit être supérieur à zéro. »
  - erreurs hors plage → « Le nombre d'erreurs doit être compris entre 0 et le nombre total de mots. »
- **Accessibilité** : conteneur `aria-live="polite"` + `role="alert"` sur les erreurs, pour annoncer les mises à jour aux technologies d'assistance.
- **Format** : `X.XX %` (ex. `60.00 %`).

## Critères d'acceptation

- ✅ Résultat affiché immédiatement après modification des deux inputs (sans clic).
- ✅ Calcul uniquement si valeurs valides (et dénominateur ≠ 0 via total > 0).
- ✅ Format clair `X.XX %`.
- ✅ Gestion des erreurs (champ vide/invalide, contraintes métier).
- ✅ Accessibilité via `aria-live`.

## Validation

- `npm run lint` : OK (seul avertissement pré-existant et non lié dans `Calculator.tsx`).
- `npm run build` : OK.

`PO_BRIEF.md` mis à jour (fonctionnalité, points d'amélioration, historique des versions v1.5).

Closes #11

https://claude.ai/code/session_0164TG1fddfGVBoqp2sFMFrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0164TG1fddfGVBoqp2sFMFrJ)_