### PR TITLE
feat(dictation-success): ajouter le tableau des 30 premières erreurs

### DIFF
--- a/PO_BRIEF.md
+++ b/PO_BRIEF.md
@@ -202,6 +202,7 @@ User → Next.js App Router → Composant Outil → État Local (useState) → A
 **Fonctionnalités** :
 - Calcul **automatique** du nombre de mots justes (total - erreurs) dès la saisie (sans bouton)
 - Calcul **réactif** du pourcentage de réussite dès que les deux champs sont valides
+- **Tableau des 30 premières erreurs** : dès qu'un nombre total de mots valide est saisi, un tableau affiche pour 1 à 30 erreurs (plafonné au total) le nombre de mots justes, le pourcentage d'erreur et le pourcentage de réussite (issue #33)
 - Affichage détaillé du calcul (format `X.XX %`)
 - Messages d'erreur contextuels (champ invalide, total ≤ 0, erreurs hors plage)
 - Accessibilité : résultat/erreur annoncés via `aria-live` (+ `role="alert"`)
@@ -447,6 +448,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 1.3 | 2026-05-18 | Coding Agent | Fix : `reusable-po-rewrite.yml` injecte désormais le titre, la description et les commentaires (questions/réponses) dans le prompt Mistral |
 | 1.4 | 2026-05-18 | Coding Agent | Rebuild en 2 workflows (`po-autocreate.yml`, `po-clarify.yml`) ; `MISTRAL_API_KEY` seul secret ; prompts externalisés (`autocreate.js`, `questions.js`, `rewrite.js`) ; suppression des `reusable-po-*.yml`, `PO_TRIGGER_TOKEN`, `MISTRAL_MODEL_ID`, `po-prompt.js`, labels `needs-mistral`/`needs-clarification` |
 | 1.5 | 2026-05-29 | Coding Agent | Calcul dynamique du pourcentage de réussite (`/dictation-success`) : suppression du bouton « Calculer », calcul réactif dérivé des champs, messages d'erreur contextuels et `aria-live` (issue #11) |
+| 1.6 | 2026-05-29 | Coding Agent | Ajout d'un tableau des 30 premières erreurs sur `/dictation-success` : affiché dès la saisie d'un total de mots valide, avec mots justes, pourcentage d'erreur et pourcentage de réussite par ligne (issue #33) |
 
 ---
 

--- a/src/app/dictation-success/DictationSuccessCalculator.tsx
+++ b/src/app/dictation-success/DictationSuccessCalculator.tsx
@@ -7,6 +7,42 @@ type Calculation =
   | { status: 'error'; message: string }
   | { status: 'success'; correctWords: number; successPercentage: number };
 
+type ErrorTableRow = {
+  errors: number;
+  correctWords: number;
+  errorPercentage: number;
+  successPercentage: number;
+};
+
+// Construit le tableau des 30 premières erreurs pour un nombre total de mots donné.
+// On s'arrête au nombre total de mots quand celui-ci est inférieur à 30.
+function computeErrorTable(totalWords: string): ErrorTableRow[] {
+  if (totalWords.trim() === '') {
+    return [];
+  }
+
+  const total = parseInt(totalWords, 10);
+
+  if (isNaN(total) || total <= 0) {
+    return [];
+  }
+
+  const maxErrors = Math.min(30, total);
+  const rows: ErrorTableRow[] = [];
+
+  for (let errors = 1; errors <= maxErrors; errors++) {
+    const correctWords = total - errors;
+    rows.push({
+      errors,
+      correctWords,
+      errorPercentage: (errors / total) * 100,
+      successPercentage: (correctWords / total) * 100,
+    });
+  }
+
+  return rows;
+}
+
 function computeResult(totalWords: string, errors: string): Calculation {
   // Tant que les deux champs ne sont pas remplis, on n'affiche ni résultat ni erreur.
   if (totalWords.trim() === '' || errors.trim() === '') {
@@ -43,6 +79,9 @@ export default function DictationSuccessCalculator() {
 
   // Le résultat est dérivé des champs : il se met à jour automatiquement à chaque saisie.
   const result = computeResult(totalWords, errors);
+
+  // Le tableau ne dépend que du nombre total de mots : il s'affiche dès que celui-ci est valide.
+  const errorTable = computeErrorTable(totalWords);
 
   return (
     <div className="rounded-lg bg-gray-100 p-6 shadow-md">
@@ -112,6 +151,40 @@ export default function DictationSuccessCalculator() {
           </div>
         )}
       </div>
+
+      {errorTable.length > 0 && (
+        <div className="mt-6 rounded-md bg-white p-4 shadow-sm">
+          <h3 className="mb-3 text-lg font-semibold text-gray-800">
+            Pourcentages pour les {errorTable.length} premières erreurs
+          </h3>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 text-left text-gray-600">
+                  <th className="py-2 pr-4 font-medium">Nombre d&apos;erreurs</th>
+                  <th className="py-2 pr-4 font-medium">Mots justes</th>
+                  <th className="py-2 pr-4 font-medium">Pourcentage d&apos;erreur</th>
+                  <th className="py-2 font-medium">Pourcentage de réussite</th>
+                </tr>
+              </thead>
+              <tbody>
+                {errorTable.map((row) => (
+                  <tr key={row.errors} className="border-b border-gray-100 last:border-b-0">
+                    <td className="py-2 pr-4 text-gray-800">{row.errors}</td>
+                    <td className="py-2 pr-4 text-gray-800">{row.correctWords}</td>
+                    <td className="py-2 pr-4 font-medium text-red-600">
+                      {row.errorPercentage.toFixed(2)} %
+                    </td>
+                    <td className="py-2 font-medium text-green-600">
+                      {row.successPercentage.toFixed(2)} %
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Affiche, dès qu'un nombre total de mots valide est saisi, un tableau listant pour 1 à 30 erreurs (plafonné au total) le nombre de mots justes, le pourcentage d'erreur et le pourcentage de réussite.

Closes #33

https://claude.ai/code/session_01XioVRggmmBMuqU1PcndKuq