### PR TITLE
Add unit converter tool with 4 categories

### DIFF
--- a/PO_BRIEF.md
+++ b/PO_BRIEF.md
@@ -45,7 +45,7 @@ Créer une collection d'outils front-end simples, accessibles et déployés sur 
 |----------|--------|
 | **Étoiles GitHub** | 1 |
 | **Forks** | 0 |
-| **Issues Ouvertes** | 4 |
+| **Issues Ouvertes** | 3 |
 | **Pull Requests** | 1 |
 | **Langages** | TypeScript (97.5%), JavaScript (1.4%), CSS (1.1%) |
 | **Dernier Commit** | 2026-05-06 |
@@ -57,7 +57,7 @@ Créer une collection d'outils front-end simples, accessibles et déployés sur 
 | Calculatrice | ✅ **Disponible** | `/calculator` | Élevée (historique, clavier) |
 | Pourcentages | ✅ **Disponible** | `/percentage` | Moyenne |
 | Pourcentage de réussite (dictée) | ✅ **Disponible** | `/dictation-success` | Moyenne |
-| Conversions | ⏳ **Planifié** | `/converter` | À définir |
+| Conversions | ✅ **Disponible** | `/converter` | Moyenne (4 catégories, taux statiques) |
 | Chronomètre | ⏳ **Planifié** | `/timer` | À définir |
 
 ### **Traffic & Analytics**
@@ -212,7 +212,23 @@ User → Next.js App Router → Composant Outil → État Local (useState) → A
 
 ---
 
-### **4. Page d'Accueil**
+### **4. Conversions (`/converter`)**
+**Fonctionnalités** :
+- 4 catégories : Longueurs (8 unités), Masse (5 unités), Températures (C/F/K), Devises (EUR/USD/GBP)
+- Calcul **réactif** à la saisie (sans bouton Calculer)
+- Bouton d'inversion rapide des unités (source ↔ cible)
+- Formatage français des nombres (locale `fr-FR`)
+- Taux de change statiques pour la V1 (EUR/USD : 1,08 · EUR/GBP : 0,86)
+- Accessibilité : `aria-live="polite"` sur le résultat, labels explicites
+
+**Points Forts** :
+- Style inline cohérent avec la Calculatrice
+- Sélecteurs d'unités lisibles (labels complets)
+- Disclaimer taux statiques visible dans la catégorie Devises
+
+---
+
+### **5. Page d'Accueil**
 **Fonctionnalités** :
 - Liste des outils sous forme de cartes (`ToolCard`)
 - Section héro avec CTA
@@ -449,6 +465,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 1.4 | 2026-05-18 | Coding Agent | Rebuild en 2 workflows (`po-autocreate.yml`, `po-clarify.yml`) ; `MISTRAL_API_KEY` seul secret ; prompts externalisés (`autocreate.js`, `questions.js`, `rewrite.js`) ; suppression des `reusable-po-*.yml`, `PO_TRIGGER_TOKEN`, `MISTRAL_MODEL_ID`, `po-prompt.js`, labels `needs-mistral`/`needs-clarification` |
 | 1.5 | 2026-05-29 | Coding Agent | Calcul dynamique du pourcentage de réussite (`/dictation-success`) : suppression du bouton « Calculer », calcul réactif dérivé des champs, messages d'erreur contextuels et `aria-live` (issue #11) |
 | 1.6 | 2026-05-29 | Coding Agent | Ajout d'un tableau des 30 premières erreurs sur `/dictation-success` : affiché dès la saisie d'un total de mots valide, avec mots justes, pourcentage d'erreur et pourcentage de réussite par ligne (issue #33) |
+| 1.7 | 2026-06-05 | Coding Agent | Implémentation de l'outil Conversions (`/converter`) : 4 catégories (longueurs, masse, températures, devises), calcul réactif, styles inline cohérents, `aria-live` (issue #35) |
 
 ---
 

--- a/src/app/converter/Converter.tsx
+++ b/src/app/converter/Converter.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+type Category = "longueurs" | "masse" | "temperatures" | "devises";
+
+const CATEGORIES: { id: Category; label: string }[] = [
+  { id: "longueurs", label: "Longueurs" },
+  { id: "masse", label: "Masse" },
+  { id: "temperatures", label: "Températures" },
+  { id: "devises", label: "Devises" },
+];
+
+const UNITS: Record<Category, string[]> = {
+  longueurs: ["m", "cm", "mm", "km", "miles", "yards", "pieds", "pouces"],
+  masse: ["kg", "g", "mg", "lb", "oz"],
+  temperatures: ["Celsius", "Fahrenheit", "Kelvin"],
+  devises: ["EUR", "USD", "GBP"],
+};
+
+const UNIT_LABELS: Record<string, string> = {
+  m: "Mètres (m)",
+  cm: "Centimètres (cm)",
+  mm: "Millimètres (mm)",
+  km: "Kilomètres (km)",
+  miles: "Miles",
+  yards: "Yards",
+  pieds: "Pieds",
+  pouces: "Pouces",
+  kg: "Kilogrammes (kg)",
+  g: "Grammes (g)",
+  mg: "Milligrammes (mg)",
+  lb: "Livres (lb)",
+  oz: "Onces (oz)",
+  Celsius: "Celsius (°C)",
+  Fahrenheit: "Fahrenheit (°F)",
+  Kelvin: "Kelvin (K)",
+  EUR: "Euro (EUR)",
+  USD: "Dollar US (USD)",
+  GBP: "Livre Sterling (GBP)",
+};
+
+// Base: mètres
+const LENGTH_TO_M: Record<string, number> = {
+  m: 1,
+  cm: 0.01,
+  mm: 0.001,
+  km: 1000,
+  miles: 1609.344,
+  yards: 0.9144,
+  pieds: 0.3048,
+  pouces: 0.0254,
+};
+
+// Base: kilogrammes
+const MASS_TO_KG: Record<string, number> = {
+  kg: 1,
+  g: 0.001,
+  mg: 0.000001,
+  lb: 0.453592,
+  oz: 0.0283495,
+};
+
+// Base: EUR
+const CURRENCY_TO_EUR: Record<string, number> = {
+  EUR: 1,
+  USD: 1 / 1.08,
+  GBP: 1 / 0.86,
+};
+
+function convertLength(value: number, from: string, to: string): number {
+  return (value * LENGTH_TO_M[from]) / LENGTH_TO_M[to];
+}
+
+function convertMass(value: number, from: string, to: string): number {
+  return (value * MASS_TO_KG[from]) / MASS_TO_KG[to];
+}
+
+function convertTemperature(value: number, from: string, to: string): number {
+  let celsius: number;
+  if (from === "Celsius") celsius = value;
+  else if (from === "Fahrenheit") celsius = (value - 32) * (5 / 9);
+  else celsius = value - 273.15;
+
+  if (to === "Celsius") return celsius;
+  if (to === "Fahrenheit") return celsius * (9 / 5) + 32;
+  return celsius + 273.15;
+}
+
+function convertCurrency(value: number, from: string, to: string): number {
+  const inEur = value * CURRENCY_TO_EUR[from];
+  return inEur / CURRENCY_TO_EUR[to];
+}
+
+function convert(category: Category, value: number, from: string, to: string): number {
+  if (category === "longueurs") return convertLength(value, from, to);
+  if (category === "masse") return convertMass(value, from, to);
+  if (category === "temperatures") return convertTemperature(value, from, to);
+  return convertCurrency(value, from, to);
+}
+
+function formatResult(value: number): string {
+  if (!isFinite(value)) return "—";
+  const abs = Math.abs(value);
+  const maximumFractionDigits = abs === 0 ? 0 : abs < 0.001 ? 10 : abs < 1 ? 6 : abs < 1000 ? 4 : 2;
+  return value.toLocaleString("fr-FR", { maximumFractionDigits });
+}
+
+const palette = {
+  bg: "#FDF6F4",
+  primary: "#E07B72",
+  primaryHover: "#C9524A",
+  dark: "#2C1A17",
+  border: "#EDD9D5",
+  secondary: "#7A5550",
+  cardBg: "#FFFFFF",
+  tabBg: "#FEF0ED",
+};
+
+export default function Converter() {
+  const [category, setCategory] = useState<Category>("longueurs");
+  const [input, setInput] = useState("");
+  const [fromUnit, setFromUnit] = useState(UNITS.longueurs[0]);
+  const [toUnit, setToUnit] = useState(UNITS.longueurs[1]);
+  const [tabHover, setTabHover] = useState<Category | null>(null);
+
+  const units = UNITS[category];
+  const numericValue = parseFloat(input.replace(",", "."));
+  const hasResult = input !== "" && !isNaN(numericValue);
+  const result = hasResult ? formatResult(convert(category, numericValue, fromUnit, toUnit)) : "";
+
+  function handleCategoryChange(cat: Category) {
+    setCategory(cat);
+    setInput("");
+    setFromUnit(UNITS[cat][0]);
+    setToUnit(UNITS[cat][1]);
+  }
+
+  function handleSwap() {
+    setFromUnit(toUnit);
+    setToUnit(fromUnit);
+  }
+
+  return (
+    <div
+      style={{
+        minHeight: "100%",
+        background: palette.bg,
+        padding: "40px 16px 80px",
+        fontFamily: "var(--font-dm-sans), sans-serif",
+      }}
+    >
+      <div style={{ maxWidth: "540px", margin: "0 auto" }}>
+        {/* Back link */}
+        <Link
+          href="/"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "6px",
+            color: palette.secondary,
+            textDecoration: "none",
+            fontSize: "14px",
+            marginBottom: "28px",
+          }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M19 12H5M12 5l-7 7 7 7" />
+          </svg>
+          Retour
+        </Link>
+
+        {/* Title */}
+        <h1
+          style={{
+            fontFamily: "var(--font-dm-serif)",
+            fontSize: "32px",
+            fontWeight: 400,
+            color: palette.dark,
+            marginBottom: "8px",
+          }}
+        >
+          Conversions
+        </h1>
+        <p style={{ color: palette.secondary, fontSize: "15px", marginBottom: "32px" }}>
+          Unités de mesure, températures, devises
+        </p>
+
+        {/* Category tabs */}
+        <div
+          role="tablist"
+          aria-label="Catégorie de conversion"
+          style={{
+            display: "flex",
+            gap: "8px",
+            flexWrap: "wrap",
+            marginBottom: "28px",
+          }}
+        >
+          {CATEGORIES.map((cat) => {
+            const active = category === cat.id;
+            const hovered = tabHover === cat.id;
+            return (
+              <button
+                key={cat.id}
+                role="tab"
+                aria-selected={active}
+                onClick={() => handleCategoryChange(cat.id)}
+                onMouseEnter={() => setTabHover(cat.id)}
+                onMouseLeave={() => setTabHover(null)}
+                style={{
+                  padding: "8px 18px",
+                  borderRadius: "999px",
+                  border: `1.5px solid ${active ? palette.primary : palette.border}`,
+                  background: active ? palette.primary : hovered ? palette.tabBg : "#fff",
+                  color: active ? "#fff" : palette.dark,
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  cursor: "pointer",
+                  transition: "all 0.15s",
+                  fontFamily: "inherit",
+                }}
+              >
+                {cat.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Converter card */}
+        <div
+          style={{
+            background: palette.cardBg,
+            border: `1.5px solid ${palette.border}`,
+            borderRadius: "16px",
+            padding: "28px",
+          }}
+        >
+          {/* From field */}
+          <div style={{ marginBottom: "20px" }}>
+            <label
+              htmlFor="input-value"
+              style={{ display: "block", fontSize: "13px", fontWeight: 600, color: palette.secondary, marginBottom: "8px" }}
+            >
+              De
+            </label>
+            <div style={{ display: "flex", gap: "10px" }}>
+              <input
+                id="input-value"
+                type="text"
+                inputMode="decimal"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="0"
+                aria-label="Valeur à convertir"
+                style={{
+                  flex: 1,
+                  padding: "12px 14px",
+                  border: `1.5px solid ${palette.border}`,
+                  borderRadius: "10px",
+                  fontSize: "20px",
+                  fontFamily: "var(--font-jetbrains-mono), monospace",
+                  color: palette.dark,
+                  background: palette.bg,
+                  outline: "none",
+                  minWidth: 0,
+                }}
+              />
+              <select
+                value={fromUnit}
+                onChange={(e) => setFromUnit(e.target.value)}
+                aria-label="Unité source"
+                style={{
+                  padding: "12px 14px",
+                  border: `1.5px solid ${palette.border}`,
+                  borderRadius: "10px",
+                  fontSize: "14px",
+                  color: palette.dark,
+                  background: "#fff",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                  outline: "none",
+                  flexShrink: 0,
+                }}
+              >
+                {units.map((u) => (
+                  <option key={u} value={u}>{UNIT_LABELS[u]}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Swap button */}
+          <div style={{ display: "flex", justifyContent: "center", marginBottom: "20px" }}>
+            <button
+              onClick={handleSwap}
+              aria-label="Inverser les unités"
+              style={{
+                width: "36px",
+                height: "36px",
+                borderRadius: "50%",
+                border: `1.5px solid ${palette.border}`,
+                background: "#fff",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: palette.secondary,
+              }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M7 16V4m0 0L3 8m4-4l4 4" />
+                <path d="M17 8v12m0 0l4-4m-4 4l-4-4" />
+              </svg>
+            </button>
+          </div>
+
+          {/* To field */}
+          <div>
+            <label
+              htmlFor="result-display"
+              style={{ display: "block", fontSize: "13px", fontWeight: 600, color: palette.secondary, marginBottom: "8px" }}
+            >
+              Vers
+            </label>
+            <div style={{ display: "flex", gap: "10px" }}>
+              <div
+                id="result-display"
+                aria-live="polite"
+                aria-label="Résultat de la conversion"
+                style={{
+                  flex: 1,
+                  padding: "12px 14px",
+                  border: `1.5px solid ${palette.border}`,
+                  borderRadius: "10px",
+                  fontSize: "20px",
+                  fontFamily: "var(--font-jetbrains-mono), monospace",
+                  color: hasResult ? palette.primary : palette.border,
+                  background: palette.bg,
+                  minWidth: 0,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
+                {hasResult ? result : "0"}
+              </div>
+              <select
+                value={toUnit}
+                onChange={(e) => setToUnit(e.target.value)}
+                aria-label="Unité cible"
+                style={{
+                  padding: "12px 14px",
+                  border: `1.5px solid ${palette.border}`,
+                  borderRadius: "10px",
+                  fontSize: "14px",
+                  color: palette.dark,
+                  background: "#fff",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                  outline: "none",
+                  flexShrink: 0,
+                }}
+              >
+                {units.map((u) => (
+                  <option key={u} value={u}>{UNIT_LABELS[u]}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Devises disclaimer */}
+          {category === "devises" && (
+            <p
+              style={{
+                marginTop: "16px",
+                fontSize: "12px",
+                color: palette.secondary,
+                textAlign: "center",
+              }}
+            >
+              Taux indicatifs statiques — EUR/USD : 1,08 · EUR/GBP : 0,86
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/converter/page.tsx
+++ b/src/app/converter/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import Converter from "./Converter";
+
+export const metadata: Metadata = {
+  title: "Conversions",
+  description: "Convertissez facilement des unités de mesure, températures et devises.",
+};
+
+export default function ConverterPage() {
+  return (
+    <main style={{ flex: 1 }}>
+      <Converter />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,8 +75,9 @@ const tools = [
     icon: <ConvertIcon />,
     name: "Conversions",
     description: "Unités de mesure, températures, devises",
-    tag: "Bientôt",
-    available: false,
+    tag: "Sciences",
+    available: true,
+    href: "/converter",
   },
   {
     id: "timer",


### PR DESCRIPTION
## Summary
Implements a new `/converter` page that provides real-time conversion across 4 categories: lengths (8 units), mass (5 units), temperatures (Celsius/Fahrenheit/Kelvin), and currencies (EUR/USD/GBP).

## Changes
- **New Converter component** (`src/app/converter/Converter.tsx`):
  - Reactive conversion calculations triggered on input change (no "Calculate" button)
  - Unit swap button for quick source ↔ target inversion
  - French number formatting using `toLocaleString("fr-FR")`
  - Conversion functions for lengths (base: meters), mass (base: kg), temperatures, and currencies (base: EUR with static rates)
  - Accessible result display with `aria-live="polite"` for screen readers
  - Inline styling consistent with existing calculator tool
  - Static currency rates disclaimer for devises category (EUR/USD: 1.08, EUR/GBP: 0.86)

- **New converter page** (`src/app/converter/page.tsx`):
  - Server component with metadata for SEO
  - Wraps Converter component in main element

- **Updated home page** (`src/app/page.tsx`):
  - Marked "Conversions" tool as available
  - Added `/converter` route link
  - Changed tag from "Bientôt" to "Sciences"

- **Updated project brief** (`PO_BRIEF.md`):
  - Marked Conversions as ✅ Available
  - Decremented open issues count (4 → 3)
  - Added feature documentation with implementation details

## Implementation Details
- Conversion logic uses base unit approach (e.g., all lengths convert through meters)
- Result formatting adapts decimal places based on magnitude (0–10 decimals)
- Category switching resets input and unit selections to defaults
- All form inputs include proper ARIA labels and semantic HTML

https://claude.ai/code/session_01M4V3GxAQbxX2uRf65BJVKm