### PR TITLE
Add multiplication tables learning game

### DIFF
--- a/PO_BRIEF.md
+++ b/PO_BRIEF.md
@@ -58,6 +58,7 @@ Créer une collection d'outils front-end simples, accessibles et déployés sur 
 | Pourcentages | ✅ **Disponible** | `/percentage` | Moyenne |
 | Pourcentage de réussite (dictée) | ✅ **Disponible** | `/dictation-success` | Moyenne |
 | Conversions | ✅ **Disponible** | `/converter` | Moyenne (4 catégories, taux statiques) |
+| Tables de multiplication (jeu) | ✅ **Disponible** | `/multiplication` | Moyenne (quiz, score, séries) |
 | Chronomètre | ⏳ **Planifié** | `/timer` | À définir |
 
 ### **Traffic & Analytics**
@@ -228,7 +229,28 @@ User → Next.js App Router → Composant Outil → État Local (useState) → A
 
 ---
 
-### **5. Page d'Accueil**
+### **5. Tables de Multiplication (`/multiplication`)**
+**Fonctionnalités** :
+- **Jeu d'apprentissage** des tables de multiplication (multiplications à un chiffre, facteurs de 1 à 9)
+- Sélecteur de table : **Mélange** (aléatoire) ou une table précise (×1 à ×9)
+- Validation au clavier (**Entrée**) ou au bouton, puis passage à la question suivante
+- Retour visuel immédiat (bonne réponse en vert, réponse attendue affichée en cas d'erreur), annoncé via `aria-live`
+- Suivi de score : **bonnes réponses / total**, **série** en cours et **record** de série (encouragement tous les 5 d'affilée)
+- Bouton **Recommencer** pour réinitialiser le score
+- Première question déterministe (rendu serveur/client identique, aucun écart d'hydratation)
+
+**Points Forts** :
+- Style inline cohérent avec la Calculatrice et les Conversions
+- Gestion du focus pour enchaîner les questions sans la souris
+- Accessibilité : labels explicites, feedback `role="status"` / `aria-live`
+
+**Points à Améliorer** :
+- Pas de persistance du record entre les sessions (cf. P005)
+- Une seule opération (multiplication) — extensible à d'autres opérations (cf. P016)
+
+---
+
+### **6. Page d'Accueil**
 **Fonctionnalités** :
 - Liste des outils sous forme de cartes (`ToolCard`)
 - Section héro avec CTA
@@ -276,6 +298,7 @@ User → Next.js App Router → Composant Outil → État Local (useState) → A
 | **P013** | **Pas de partage social** | 📤 **Viralité** | Ajouter boutons de partage (Twitter, LinkedIn) | Faible | ⭐⭐ |
 | **P014** | **Design system incomplet** | 🎨 **Cohérence future** | Créer un design system (Storybook) | Élevé | ⭐⭐ |
 | **P015** | **Pas de documentation utilisateur** | 📖 **Adoption** | Ajouter une page `/docs` ou `/help` | Moyen | ⭐⭐ |
+| **P016** | **Jeu d'apprentissage limité à la multiplication** | 🎓 **Potentiel éducatif sous-exploité** | Ajouter d'autres opérations (addition, soustraction, division), des niveaux de difficulté et la persistance du record (`localStorage`) | Moyen | ⭐⭐⭐ |
 
 ---
 
@@ -435,6 +458,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 2026-05-18 | **Convention de nommage `po-*` / `reusable-po-*`** | Nommage clair et cohérent des workflows (fin des suffixes `_handler`/`-v2`) | PO |
 | 2026-05-18 | **Correction du prompt de réécriture (`reusable-po-rewrite.yml`)** | Le prompt ignorait titre/description/réponses de l'issue : injection du contexte complet (issue + échanges de clarification) pour une réécriture pertinente | Coding Agent |
 | 2026-05-18 | **Rebuild en 2 workflows (`po-autocreate.yml`, `po-clarify.yml`)** | Simplification : `MISTRAL_API_KEY` seul secret, prompts externalisés dans `.github/prompts/`, suppression de tous les `reusable-po-*.yml`, de `PO_TRIGGER_TOKEN` et `MISTRAL_MODEL_ID` | Coding Agent |
+| 2026-06-10 | **Introduction d'une catégorie « Jeu » + premier jeu éducatif** | Tuile « Tables de multiplication » : exercice de multiplications à un chiffre pour apprendre les tables, pensé comme une base extensible à d'autres opérations | Coding Agent |
 
 ### **Questions Ouvertes**
 1. **Faut-il ajouter un backend ?**
@@ -466,8 +490,9 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 1.5 | 2026-05-29 | Coding Agent | Calcul dynamique du pourcentage de réussite (`/dictation-success`) : suppression du bouton « Calculer », calcul réactif dérivé des champs, messages d'erreur contextuels et `aria-live` (issue #11) |
 | 1.6 | 2026-05-29 | Coding Agent | Ajout d'un tableau des 30 premières erreurs sur `/dictation-success` : affiché dès la saisie d'un total de mots valide, avec mots justes, pourcentage d'erreur et pourcentage de réussite par ligne (issue #33) |
 | 1.7 | 2026-06-05 | Coding Agent | Implémentation de l'outil Conversions (`/converter`) : 4 catégories (longueurs, masse, températures, devises), calcul réactif, styles inline cohérents, `aria-live` (issue #35) |
+| 1.8 | 2026-06-10 | Coding Agent | Ajout d'une tuile « Jeu » et d'un jeu d'apprentissage des tables de multiplication (`/multiplication`) : multiplications à un chiffre, sélecteur de table (mélange ou ×1–×9), score/série/record, validation clavier et feedback `aria-live` |
 
 ---
 
 *Document généré automatiquement à partir de l'analyse du dépôt [Manidrim/my-utils-for-versel](https://github.com/Manidrim/my-utils-for-versel).*
-*Dernière mise à jour : 2026-05-29.*
+*Dernière mise à jour : 2026-06-10.*

--- a/src/app/multiplication/MultiplicationGame.tsx
+++ b/src/app/multiplication/MultiplicationGame.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { useRef, useState } from "react";
+import Link from "next/link";
+
+type Question = { a: number; b: number };
+type Feedback = { correct: boolean; expected: number; a: number; b: number };
+type TableChoice = number | "all";
+
+const TABLES: TableChoice[] = ["all", 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+const palette = {
+  bg: "#FDF6F4",
+  primary: "#E07B72",
+  primaryHover: "#C9524A",
+  dark: "#2C1A17",
+  border: "#EDD9D5",
+  secondary: "#7A5550",
+  cardBg: "#FFFFFF",
+  tabBg: "#FEF0ED",
+  success: "#2F9E6B",
+  successBg: "#E8F6EF",
+  error: "#C9524A",
+  errorBg: "#FCEBE9",
+};
+
+function randInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function makeQuestion(table: TableChoice): Question {
+  if (table === "all") {
+    return { a: randInt(1, 9), b: randInt(1, 9) };
+  }
+  // Garde la table choisie comme l'un des facteurs ; côté aléatoire pour varier.
+  const other = randInt(1, 9);
+  return Math.random() < 0.5 ? { a: table, b: other } : { a: other, b: table };
+}
+
+export default function MultiplicationGame() {
+  const [table, setTable] = useState<TableChoice>("all");
+  // Première question déterministe (identique serveur/client) pour éviter tout
+  // écart d'hydratation ; les suivantes sont aléatoires via les gestionnaires.
+  const [question, setQuestion] = useState<Question>({ a: 3, b: 4 });
+  const [answer, setAnswer] = useState("");
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [score, setScore] = useState({ correct: 0, total: 0 });
+  const [streak, setStreak] = useState(0);
+  const [best, setBest] = useState(0);
+  const [tabHover, setTabHover] = useState<TableChoice | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function focusInput() {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }
+
+  function handleTableChange(choice: TableChoice) {
+    setTable(choice);
+    setQuestion(makeQuestion(choice));
+    setAnswer("");
+    setFeedback(null);
+    focusInput();
+  }
+
+  function handleNext() {
+    setQuestion(makeQuestion(table));
+    setAnswer("");
+    setFeedback(null);
+    focusInput();
+  }
+
+  function handleValidate() {
+    if (answer === "") return;
+    const expected = question.a * question.b;
+    const correct = parseInt(answer, 10) === expected;
+    setFeedback({ correct, expected, a: question.a, b: question.b });
+    setScore((s) => ({
+      correct: s.correct + (correct ? 1 : 0),
+      total: s.total + 1,
+    }));
+    if (correct) {
+      const nextStreak = streak + 1;
+      setStreak(nextStreak);
+      setBest((b) => Math.max(b, nextStreak));
+    } else {
+      setStreak(0);
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (feedback) handleNext();
+    else handleValidate();
+  }
+
+  function handleReset() {
+    setScore({ correct: 0, total: 0 });
+    setStreak(0);
+    setBest(0);
+    handleNext();
+  }
+
+  const inputBorder = feedback
+    ? feedback.correct
+      ? palette.success
+      : palette.error
+    : palette.border;
+
+  const stats: { label: string; value: string | number }[] = [
+    { label: "Bonnes réponses", value: `${score.correct}/${score.total}` },
+    { label: "Série", value: streak },
+    { label: "Record", value: best },
+  ];
+
+  return (
+    <div
+      style={{
+        minHeight: "100%",
+        background: palette.bg,
+        padding: "40px 16px 80px",
+        fontFamily: "var(--font-dm-sans), sans-serif",
+      }}
+    >
+      <div style={{ maxWidth: "540px", margin: "0 auto" }}>
+        {/* Back link */}
+        <Link
+          href="/"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "6px",
+            color: palette.secondary,
+            textDecoration: "none",
+            fontSize: "14px",
+            marginBottom: "28px",
+          }}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M19 12H5M12 5l-7 7 7 7" />
+          </svg>
+          Retour
+        </Link>
+
+        {/* Title */}
+        <h1
+          style={{
+            fontFamily: "var(--font-dm-serif)",
+            fontSize: "32px",
+            fontWeight: 400,
+            color: palette.dark,
+            marginBottom: "8px",
+          }}
+        >
+          Tables de multiplication
+        </h1>
+        <p style={{ color: palette.secondary, fontSize: "15px", marginBottom: "32px" }}>
+          Entraîne-toi aux multiplications à un chiffre.
+        </p>
+
+        {/* Table selector */}
+        <div
+          role="group"
+          aria-label="Choisir une table"
+          style={{
+            display: "flex",
+            gap: "8px",
+            flexWrap: "wrap",
+            marginBottom: "28px",
+          }}
+        >
+          {TABLES.map((t) => {
+            const active = table === t;
+            const hovered = tabHover === t;
+            return (
+              <button
+                key={String(t)}
+                type="button"
+                aria-pressed={active}
+                onClick={() => handleTableChange(t)}
+                onMouseEnter={() => setTabHover(t)}
+                onMouseLeave={() => setTabHover(null)}
+                style={{
+                  padding: "8px 16px",
+                  borderRadius: "999px",
+                  border: `1.5px solid ${active ? palette.primary : palette.border}`,
+                  background: active ? palette.primary : hovered ? palette.tabBg : "#fff",
+                  color: active ? "#fff" : palette.dark,
+                  fontSize: "14px",
+                  fontWeight: 500,
+                  cursor: "pointer",
+                  transition: "all 0.15s",
+                  fontFamily: "inherit",
+                }}
+              >
+                {t === "all" ? "Mélange" : `×${t}`}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Game card */}
+        <div
+          style={{
+            background: palette.cardBg,
+            border: `1.5px solid ${palette.border}`,
+            borderRadius: "16px",
+            padding: "28px",
+          }}
+        >
+          <form onSubmit={handleSubmit}>
+            {/* Equation */}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexWrap: "wrap",
+                gap: "14px",
+                marginBottom: "20px",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--font-jetbrains-mono), monospace",
+                  fontSize: "40px",
+                  fontWeight: 500,
+                  color: palette.dark,
+                  letterSpacing: "0.01em",
+                }}
+              >
+                {`${question.a} × ${question.b} =`}
+              </span>
+              <input
+                ref={inputRef}
+                type="text"
+                inputMode="numeric"
+                autoComplete="off"
+                value={answer}
+                readOnly={feedback !== null}
+                onChange={(e) =>
+                  setAnswer(e.target.value.replace(/[^0-9]/g, "").slice(0, 3))
+                }
+                placeholder="?"
+                aria-label={`Résultat de ${question.a} multiplié par ${question.b}`}
+                style={{
+                  width: "96px",
+                  padding: "10px 12px",
+                  border: `2px solid ${inputBorder}`,
+                  borderRadius: "10px",
+                  fontSize: "32px",
+                  fontFamily: "var(--font-jetbrains-mono), monospace",
+                  fontWeight: 500,
+                  textAlign: "center",
+                  color: palette.dark,
+                  background: palette.bg,
+                  outline: "none",
+                }}
+              />
+            </div>
+
+            {/* Feedback */}
+            <div
+              role="status"
+              aria-live="polite"
+              style={{
+                minHeight: "44px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                marginBottom: "16px",
+                padding: feedback ? "8px 14px" : 0,
+                borderRadius: "10px",
+                background: feedback
+                  ? feedback.correct
+                    ? palette.successBg
+                    : palette.errorBg
+                  : "transparent",
+                color: feedback
+                  ? feedback.correct
+                    ? palette.success
+                    : palette.error
+                  : "transparent",
+                fontSize: "15px",
+                fontWeight: 600,
+                textAlign: "center",
+              }}
+            >
+              {feedback
+                ? feedback.correct
+                  ? streak > 0 && streak % 5 === 0
+                    ? `🔥 Série de ${streak} ! Bravo !`
+                    : "✓ Bravo !"
+                  : `✗ Raté — ${feedback.a} × ${feedback.b} = ${feedback.expected}`
+                : ""}
+            </div>
+
+            {/* Action button */}
+            <button
+              type="submit"
+              disabled={!feedback && answer === ""}
+              style={{
+                width: "100%",
+                padding: "14px",
+                borderRadius: "12px",
+                border: "none",
+                background:
+                  !feedback && answer === "" ? palette.border : palette.primary,
+                color: "#fff",
+                fontSize: "16px",
+                fontWeight: 600,
+                fontFamily: "inherit",
+                cursor: !feedback && answer === "" ? "default" : "pointer",
+                transition: "background 0.15s",
+              }}
+            >
+              {feedback ? "Question suivante" : "Valider"}
+            </button>
+          </form>
+
+          {/* Stats */}
+          <div
+            style={{
+              display: "flex",
+              marginTop: "24px",
+              paddingTop: "20px",
+              borderTop: `1.5px solid ${palette.border}`,
+            }}
+          >
+            {stats.map((s) => (
+              <div key={s.label} style={{ flex: 1, textAlign: "center" }}>
+                <div
+                  style={{
+                    fontFamily: "var(--font-jetbrains-mono), monospace",
+                    fontSize: "22px",
+                    fontWeight: 600,
+                    color: palette.dark,
+                  }}
+                >
+                  {s.value}
+                </div>
+                <div
+                  style={{
+                    fontSize: "12px",
+                    color: palette.secondary,
+                    marginTop: "2px",
+                  }}
+                >
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {score.total > 0 && (
+            <div style={{ textAlign: "center", marginTop: "16px" }}>
+              <button
+                type="button"
+                onClick={handleReset}
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  color: palette.secondary,
+                  fontSize: "13px",
+                  fontFamily: "inherit",
+                  cursor: "pointer",
+                  textDecoration: "underline",
+                }}
+              >
+                Recommencer
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/multiplication/page.tsx
+++ b/src/app/multiplication/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import MultiplicationGame from "./MultiplicationGame";
+
+export const metadata: Metadata = {
+  title: "Tables de multiplication",
+  description:
+    "Jeu d'apprentissage : révise tes tables de multiplication avec des multiplications à un chiffre.",
+};
+
+export default function MultiplicationPage() {
+  return (
+    <main style={{ flex: 1 }}>
+      <MultiplicationGame />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,14 @@ const ConvertIcon = () => (
   </svg>
 );
 
+const MultiplicationIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="4" />
+    <line x1="9" y1="9" x2="15" y2="15" />
+    <line x1="15" y1="9" x2="9" y2="15" />
+  </svg>
+);
+
 const TimerIcon = () => (
   <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
     <circle cx="12" cy="13" r="8" /><path d="M12 9v4l2.5 2.5" />
@@ -78,6 +86,15 @@ const tools = [
     tag: "Sciences",
     available: true,
     href: "/converter",
+  },
+  {
+    id: "multiplication",
+    icon: <MultiplicationIcon />,
+    name: "Tables de multiplication",
+    description: "Jeu d'apprentissage : révise tes tables avec des multiplications à un chiffre",
+    tag: "Jeu",
+    available: true,
+    href: "/multiplication",
   },
   {
     id: "timer",


### PR DESCRIPTION
Add a new "Jeu" tile on the home page linking to /multiplication, a
single-digit multiplication quiz to practise the times tables.

- New /multiplication route (page + client component) styled to match
  the Converter tool (shared palette, back link, card, aria-live)
- Table selector: mix or a specific table (×1–×9)
- Keyboard-driven flow (Enter to validate then advance), running score,
  current streak, best streak and a reset button
- First question is deterministic so server and client render the same
  markup (no hydration mismatch); subsequent questions are random
- Update PO_BRIEF.md (feature status, new feature section, P016, history)

https://claude.ai/code/session_01PEqNVyjrSUeLNYFZiT9Rcn