### PR TITLE
Ajoute un dossier de skills projet (.claude/skills)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,28 @@
+# Skills du projet
+
+Skills Claude Code spécifiques à `my-utils-for-versel`, pour accélérer le
+développement et la recherche de règles métier. Chaque sous-dossier contient un
+`SKILL.md` (frontmatter `name` + `description`) chargé automatiquement par
+Claude Code quand la tâche correspond à sa description.
+
+| Skill | Usage |
+|-------|-------|
+| [`nouvel-outil`](./nouvel-outil/SKILL.md) | Scaffolder un nouvel outil/page en respectant les conventions (App Router, styles inline, palette, accessibilité, fr-FR) et l'enregistrer sur la page d'accueil. |
+| [`regles-metier`](./regles-metier/SKILL.md) | Localiser et comprendre les règles métier : formules, taux de change, formatage fr-FR, validations, accessibilité. |
+
+## Ajouter une skill
+
+Crée `.claude/skills/<nom>/SKILL.md` avec un frontmatter :
+
+```markdown
+---
+name: nom-de-la-skill
+description: >-
+  Quand et pourquoi utiliser cette skill (déclencheurs explicites).
+---
+
+# Contenu de la skill
+```
+
+Garde les descriptions orientées « déclencheur » (quand l'invoquer) pour que la
+sélection automatique soit pertinente.

--- a/.claude/skills/nouvel-outil/SKILL.md
+++ b/.claude/skills/nouvel-outil/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: nouvel-outil
+description: >-
+  Guide pas-à-pas pour ajouter un nouvel outil (page) à my-utils-for-versel en
+  respectant les conventions du projet (App Router Next.js 16, styles inline,
+  palette, accessibilité, locale fr-FR). À utiliser quand on demande de créer,
+  scaffolder ou ajouter un nouvel outil / une nouvelle page / un nouvel
+  utilitaire, ou d'enregistrer un outil sur la page d'accueil.
+---
+
+# Ajouter un nouvel outil
+
+Ce projet est une collection d'outils front-end (Next.js 16 App Router,
+TypeScript, pas de backend). Chaque outil = un dossier sous `src/app/<slug>/`
+contenant une `page.tsx` (server component, exporte les `metadata`) et un
+composant métier `Outil.tsx` (`"use client"`).
+
+⚠️ **Avant de coder** : ce Next.js a des breaking changes vs ton training.
+Lis le guide pertinent dans `node_modules/next/dist/docs/` et respecte les
+avis de dépréciation (voir `AGENTS.md`).
+
+## Étapes
+
+### 1. Créer le dossier et la page serveur
+`src/app/<slug>/page.tsx` :
+
+```tsx
+import type { Metadata } from "next";
+import MonOutil from "./MonOutil";
+
+export const metadata: Metadata = {
+  title: "Nom de l'outil",                 // devient "Nom de l'outil · Toolbox"
+  description: "Phrase courte décrivant l'outil.",
+};
+
+export default function MonOutilPage() {
+  return (
+    <main style={{ flex: 1 }}>
+      <MonOutil />
+    </main>
+  );
+}
+```
+
+### 2. Créer le composant métier
+`src/app/<slug>/MonOutil.tsx` — commence par `"use client";`, état local via
+`useState`, tous les calculs côté client. Structure de référence :
+`src/app/converter/Converter.tsx`.
+
+Trame minimale (lien retour + titre + carte) :
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+const palette = {
+  bg: "#FDF6F4",
+  primary: "#E07B72",
+  primaryHover: "#C9524A",
+  dark: "#2C1A17",
+  border: "#EDD9D5",
+  secondary: "#7A5550",
+  cardBg: "#FFFFFF",
+  tabBg: "#FEF0ED",
+};
+
+export default function MonOutil() {
+  const [input, setInput] = useState("");
+
+  return (
+    <div style={{ minHeight: "100%", background: palette.bg, padding: "40px 16px 80px", fontFamily: "var(--font-dm-sans), sans-serif" }}>
+      <div style={{ maxWidth: "540px", margin: "0 auto" }}>
+        <Link href="/" style={{ display: "inline-flex", alignItems: "center", gap: "6px", color: palette.secondary, textDecoration: "none", fontSize: "14px", marginBottom: "28px" }}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M19 12H5M12 5l-7 7 7 7" />
+          </svg>
+          Retour
+        </Link>
+        <h1 style={{ fontFamily: "var(--font-dm-serif)", fontSize: "32px", fontWeight: 400, color: palette.dark, marginBottom: "8px" }}>
+          Nom de l'outil
+        </h1>
+        {/* … carte + champs … */}
+      </div>
+    </div>
+  );
+}
+```
+
+### 3. Enregistrer l'outil sur la page d'accueil
+Dans `src/app/page.tsx` :
+- Crée un petit composant icône SVG (24×24, `stroke="currentColor"`,
+  `strokeWidth="1.5"`) sur le modèle de `CalcIcon`, `ConvertIcon`, etc.
+- Ajoute une entrée dans le tableau `tools` :
+
+```tsx
+{
+  id: "<slug>",
+  icon: <MonIcon />,
+  name: "Nom de l'outil",
+  description: "Phrase courte (≤ ~60 caractères).",
+  tag: "Maths",            // tags existants : Maths, Éducation, Sciences, Jeu, Bientôt
+  available: true,
+  href: "/<slug>",
+},
+```
+
+> Pour un outil pas encore prêt : `available: false`, `tag: "Bientôt"`, et
+> **pas** de `href` (voir l'entrée `timer`).
+
+### 4. Mettre à jour la documentation
+- `README.md` : ajoute une ligne dans la liste **Outils**.
+- `PO_BRIEF.md` : **obligatoire** (voir `AGENTS.md`). Mets à jour le tableau
+  *Statut des Fonctionnalités*, la section *Fonctionnalités Existantes*,
+  ajoute une ligne à *Historique des Versions* et à *Notes & Décisions* si
+  une décision a été prise.
+
+### 5. Vérifier
+```bash
+npm run lint
+npm run build
+```
+
+## Conventions à respecter (voir aussi la skill `regles-metier`)
+
+- **Styles inline** (objets `style={{…}}`), pas de Tailwind pour les nouveaux
+  outils : c'est le style retenu (cf. Calculatrice/Conversions/Multiplication).
+  Les anciens outils en Tailwind (`percentage`) sont une dette à résorber
+  (P002), ne pas l'imiter.
+- **Palette** : utiliser exactement les couleurs ci-dessus.
+- **Polices** (variables CSS définies dans `layout.tsx`) :
+  `--font-dm-serif` (titres), `--font-dm-sans` (texte),
+  `--font-jetbrains-mono` (chiffres/résultats).
+- **Locale fr-FR** : séparateur décimal = virgule. Parser une saisie avec
+  `parseFloat(input.replace(",", "."))` ; afficher avec
+  `value.toLocaleString("fr-FR", { … })`.
+- **Calcul réactif** : pas de bouton « Calculer » — le résultat se dérive de
+  l'état à chaque frappe (cf. Conversions, dictation-success).
+- **Accessibilité** : `aria-live="polite"` (ou `role="alert"` pour les
+  erreurs) sur le résultat, `aria-label`/`<label htmlFor>` sur les champs,
+  rôles sémantiques (`role="tablist"`/`"tab"` pour des onglets).
+- **Hydratation** : la valeur initiale rendue serveur et client doit être
+  identique (pas de `Math.random()`/`Date.now()` au premier rendu — cf. la
+  première question déterministe du jeu de multiplication).

--- a/.claude/skills/regles-metier/SKILL.md
+++ b/.claude/skills/regles-metier/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: regles-metier
+description: >-
+  Catalogue et localisation des règles métier de my-utils-for-versel (formules
+  de calcul, taux de change, conventions de formatage fr-FR, contraintes de
+  validation, accessibilité). À utiliser quand on cherche où vit une règle de
+  calcul, comment un résultat est obtenu, quelles unités/taux sont utilisés, ou
+  pour comprendre/modifier la logique d'un outil existant.
+---
+
+# Règles métier du projet
+
+Référence pour retrouver et comprendre la logique métier. **Pas de backend ni
+de base de données** : toute la logique est côté client dans le composant de
+chaque outil (`src/app/<slug>/<Composant>.tsx`).
+
+## Où chercher
+
+| Domaine | Fichier |
+|---------|---------|
+| Calculatrice (opérations, historique, clavier) | `src/app/calculator/Calculator.tsx` |
+| Pourcentages | `src/app/percentage/PercentageCalculator.tsx` |
+| Réussite de dictée | `src/app/dictation-success/DictationSuccessCalculator.tsx` |
+| Conversions (unités, taux) | `src/app/converter/Converter.tsx` |
+| Jeu des tables de multiplication | `src/app/multiplication/MultiplicationGame.tsx` |
+| Liste des outils + tags | `src/app/page.tsx` (tableau `tools`) |
+| Polices, palette racine, métadonnées globales | `src/app/layout.tsx` |
+
+> Pour une recherche : `grep`/Grep sur le terme métier (ex. `toLocaleString`,
+> `replace(",", ".")`, `CURRENCY_TO_EUR`, `aria-live`). La vue produit /
+> roadmap / décisions est dans `PO_BRIEF.md`.
+
+## Conventions transverses (s'appliquent à tous les outils)
+
+- **Locale fr-FR** : virgule = séparateur décimal.
+  - Lecture d'une saisie : `parseFloat(input.replace(",", "."))`.
+  - Affichage : `value.toLocaleString("fr-FR", { maximumFractionDigits: … })`.
+- **Calcul réactif** : le résultat se dérive de l'état à chaque frappe, sans
+  bouton « Calculer » (Conversions, dictation-success). La Calculatrice reste
+  l'exception (saisie d'expression puis `=`).
+- **Validation / erreurs** : entrée vide ou `NaN` ⇒ aucun résultat affiché
+  (état neutre, ex. `"0"` ou `"—"`), pas de crash. Messages d'erreur
+  contextuels annoncés via `aria-live`/`role="alert"`.
+- **Accessibilité** : résultats en `aria-live="polite"`, champs étiquetés.
+
+## Règles spécifiques par outil
+
+### Conversions (`Converter.tsx`)
+- 4 catégories : `longueurs`, `masse`, `temperatures`, `devises`.
+- Longueurs : tout passe par une **base mètre** (`LENGTH_TO_M`) ;
+  `résultat = value * LENGTH_TO_M[from] / LENGTH_TO_M[to]`.
+- Masse : **base kilogramme** (`MASS_TO_KG`), même formule.
+- Températures : conversion via le **Celsius** comme pivot
+  (F→C : `(v-32)*5/9` ; K→C : `v-273.15` ; et inverses).
+- Devises : **base EUR** (`CURRENCY_TO_EUR`). Taux **statiques V1** :
+  EUR/USD = 1,08 · EUR/GBP = 0,86 (disclaimer affiché dans la catégorie
+  Devises). ⚠️ Toute modif de taux se fait ici **et** dans le disclaimer.
+- `formatResult` adapte le nombre de décimales selon l'ordre de grandeur ;
+  une valeur non finie s'affiche `—`.
+
+### Réussite de dictée (`DictationSuccessCalculator.tsx`)
+- `mots justes = total - erreurs` (calculé automatiquement à la saisie).
+- `% réussite` calculé dès que les deux champs sont valides, format `X.XX %`.
+- Contraintes : `total > 0`, `0 ≤ erreurs ≤ total` (sinon message contextuel).
+- Tableau des **30 premières erreurs** (plafonné au total) : pour 1..min(30,
+  total), affiche mots justes, % d'erreur et % de réussite (issue #33).
+
+### Jeu des tables de multiplication (`MultiplicationGame.tsx`)
+- Multiplications à un chiffre, **facteurs 1 à 9**.
+- Sélecteur : *Mélange* (aléatoire) ou une table précise (×1 à ×9).
+- Score = bonnes/total ; suivi de la **série** en cours et du **record** ;
+  encouragement tous les 5 d'affilée.
+- **Première question déterministe** : identique côté serveur et client pour
+  éviter tout écart d'hydratation (pas d'aléatoire au premier rendu).
+- Record **non persisté** entre sessions (amélioration P005/P016).
+
+### Calculatrice (`Calculator.tsx`)
+- Opérations +, −, ×, ÷ ; décimales à la virgule ; historique des **6**
+  derniers calculs (cliquables) ; support clavier ; format français (espaces
+  comme séparateurs de milliers) ; affiche `Erreur` sur calcul invalide.
+- ⚠️ **Dette de sécurité (P001)** : l'évaluation utilise `Function()` (risque
+  XSS). À remplacer par un parser mathématique — ne pas étendre ce pattern.
+
+## Tags d'outils (page d'accueil)
+`Maths`, `Éducation`, `Sciences`, `Jeu`, `Bientôt`. Un outil `available:false`
+n'a pas de `href` et porte le tag `Bientôt`.
+
+## Rappel
+Après toute modification de règle métier, mets à jour `PO_BRIEF.md`
+(Fonctionnalités Existantes, Historique des Versions, Notes & Décisions) —
+c'est imposé par `AGENTS.md`.

--- a/PO_BRIEF.md
+++ b/PO_BRIEF.md
@@ -459,6 +459,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 2026-05-18 | **Correction du prompt de réécriture (`reusable-po-rewrite.yml`)** | Le prompt ignorait titre/description/réponses de l'issue : injection du contexte complet (issue + échanges de clarification) pour une réécriture pertinente | Coding Agent |
 | 2026-05-18 | **Rebuild en 2 workflows (`po-autocreate.yml`, `po-clarify.yml`)** | Simplification : `MISTRAL_API_KEY` seul secret, prompts externalisés dans `.github/prompts/`, suppression de tous les `reusable-po-*.yml`, de `PO_TRIGGER_TOKEN` et `MISTRAL_MODEL_ID` | Coding Agent |
 | 2026-06-10 | **Introduction d'une catégorie « Jeu » + premier jeu éducatif** | Tuile « Tables de multiplication » : exercice de multiplications à un chiffre pour apprendre les tables, pensé comme une base extensible à d'autres opérations | Coding Agent |
+| 2026-06-10 | **Ajout d'un dossier de skills projet (`.claude/skills/`)** | Skills Claude Code `nouvel-outil` (scaffolding d'un outil selon les conventions) et `regles-metier` (catalogue/localisation des règles métier) pour accélérer le développement et la recherche de logique métier | Coding Agent |
 
 ### **Questions Ouvertes**
 1. **Faut-il ajouter un backend ?**
@@ -491,6 +492,7 @@ Utilisez ce tableau pour évaluer chaque proposition :
 | 1.6 | 2026-05-29 | Coding Agent | Ajout d'un tableau des 30 premières erreurs sur `/dictation-success` : affiché dès la saisie d'un total de mots valide, avec mots justes, pourcentage d'erreur et pourcentage de réussite par ligne (issue #33) |
 | 1.7 | 2026-06-05 | Coding Agent | Implémentation de l'outil Conversions (`/converter`) : 4 catégories (longueurs, masse, températures, devises), calcul réactif, styles inline cohérents, `aria-live` (issue #35) |
 | 1.8 | 2026-06-10 | Coding Agent | Ajout d'une tuile « Jeu » et d'un jeu d'apprentissage des tables de multiplication (`/multiplication`) : multiplications à un chiffre, sélecteur de table (mélange ou ×1–×9), score/série/record, validation clavier et feedback `aria-live` |
+| 1.9 | 2026-06-10 | Coding Agent | Ajout d'un dossier de skills projet (`.claude/skills/`) : `nouvel-outil` (guide de scaffolding d'un outil selon les conventions) et `regles-metier` (catalogue et localisation des règles métier) pour faciliter le développement et la recherche de logique métier |
 
 ---
 


### PR DESCRIPTION
- nouvel-outil : guide de scaffolding d'un outil selon les conventions
  (App Router, styles inline, palette, accessibilité, locale fr-FR) et
  enregistrement sur la page d'accueil
- regles-metier : catalogue et localisation des règles métier (formules,
  taux de change, formatage fr-FR, validations, accessibilité)
- README du dossier de skills
- Mise à jour de PO_BRIEF.md (Notes & Décisions, Historique des Versions)

https://claude.ai/code/session_01KFJWqezPmPtX8FJxcFcEzE